### PR TITLE
Feat 메인 대시보드 요약 카드 구현

### DIFF
--- a/src/components/dashboard/SummaryCards.vue
+++ b/src/components/dashboard/SummaryCards.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="summary-cards">
+    <div class="card box-default" v-for="card in cards" :key="card.label">
+      <div class="card-icon justify-align" :class="card.bgClass">
+        <img :src="card.icon" :alt="card.label" />
+      </div>
+      <div class="card-content">
+        <p class="card-label fw-medium text-black-2">{{ card.label }}</p>
+        <p class="card-amount fw-bold text-black-1">{{ formatAmount(card.value) }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted } from "vue";
+import { useTransactionStore } from "@/stores/useTransactionStore";
+import dayjs from "dayjs";
+import mainIncome from "@/assets/icons/main-page/main-income.png";
+import mainExpense from "@/assets/icons/main-page/main-expense.png";
+import mainProfit from "@/assets/icons/main-page/main-profit.png";
+
+// TODO: useUserStore 연결 후 실제 userId로 교체
+const DUMMY_USER_ID = 1;
+
+const transactionStore = useTransactionStore();
+
+onMounted(async () => {
+  const now = dayjs();
+  await transactionStore.fetchMonthlyTransactions(
+    DUMMY_USER_ID,
+    now.year(),
+    now.month() + 1,
+  );
+});
+
+const totalIncome = computed(() =>
+  transactionStore.transactions
+    .filter((tx) => tx.type === "income")
+    .reduce((sum, tx) => sum + tx.amount, 0),
+);
+
+const totalExpense = computed(() =>
+  transactionStore.transactions
+    .filter((tx) => tx.type === "expense")
+    .reduce((sum, tx) => sum + tx.amount, 0),
+);
+
+const netProfit = computed(() => totalIncome.value - totalExpense.value);
+
+const cards = computed(() => [
+  {
+    label: "총 수입",
+    value: totalIncome.value,
+    bgClass: "bg-green-2",
+    icon: mainIncome,
+  },
+  {
+    label: "총 지출",
+    value: totalExpense.value,
+    bgClass: "bg-red-2",
+    icon: mainExpense,
+  },
+  {
+    label: "순수익",
+    value: netProfit.value,
+    bgClass: "bg-blue-1",
+    icon: mainProfit,
+  },
+]);
+
+function formatAmount(amount) {
+  const sign = amount < 0 ? "-" : "";
+  return `${sign}${Math.abs(amount).toLocaleString("ko-KR")}원`;
+}
+</script>
+
+<style scoped>
+.summary-cards {
+  display: flex;
+  gap: 20px;
+}
+
+.card {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 24px 28px;
+}
+
+.card-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  flex-shrink: 0;
+}
+
+.card-icon img {
+  width: 24px;
+  height: 24px;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.card-label {
+  margin: 0;
+  font-size: 13px;
+}
+
+.card-amount {
+  margin: 0;
+  font-size: 20px;
+}
+</style>

--- a/src/pages/DashboardView.vue
+++ b/src/pages/DashboardView.vue
@@ -1,2 +1,17 @@
-<template></template>
-<script setup></script>
+<template>
+  <div class="dashboard">
+    <SummaryCards />
+  </div>
+</template>
+
+<script setup>
+import SummaryCards from "@/components/dashboard/SummaryCards.vue";
+</script>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+</style>


### PR DESCRIPTION
  ## 1. 개요                                                                                                                                                               
  이번 달 총 수입 / 지출 / 순수익을 보여주는 요약 카드 3개를 구현합니다.                                                                                                   
                                                                                                                                                                           
  ## 2. 주요 변경 사항                                      
  - `SummaryCards.vue`: 요약 카드 컴포넌트 신규 구현
    - useTransactionStore fetchMonthlyTransactions로 이번 달 데이터 fetch
    - type별 수입/지출 합산 및 순수익 계산 computed 적용
    - 금액 한국 원화 형식(toLocaleString) 표시
  - `DashboardView.vue`: SummaryCards 컴포넌트 연결

  ## 3. 리뷰 포인트
  - userId가 현재 더미값(1) 하드코딩 — useUserStore 구현 후 교체 필요