### PR TITLE
feat 메인 대시보드 목표 달성 바 차트 구현

### DIFF
--- a/src/components/dashboard/GoalChart.vue
+++ b/src/components/dashboard/GoalChart.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="goal-chart box-default">
+    <h2 class="section-title fw-bold text-black-1">목표 달성</h2>
+
+    <div v-if="loading" class="empty-msg text-black-2">불러오는 중...</div>
+
+    <div v-else-if="goals.length === 0" class="empty-msg text-black-2">
+      등록된 목표가 없습니다.
+    </div>
+
+    <ul v-else class="goal-list">
+      <li v-for="goal in goalsWithProgress" :key="goal.id" class="goal-item">
+        <div class="goal-header">
+          <span class="goal-name fw-medium text-black-1">{{ goal.itemName }}</span>
+          <span class="goal-status fw-semibold" :class="goal.achieved ? 'text-green-1' : 'text-black-2'">
+            {{ goal.achieved ? "달성" : `${formatAmount(netProfit)} / ${formatAmount(goal.targetAmount)}` }}
+          </span>
+        </div>
+
+        <div class="bar-track">
+          <div
+            class="bar-fill"
+            :class="goal.achieved ? 'bg-green-1' : 'bg-yellow-1'"
+            :style="{ width: `${goal.progressRate}%` }"
+          ></div>
+        </div>
+
+        <div v-if="goal.achieved" class="celebrate">
+          <img :src="smileIcon" alt="달성 축하" class="celebrate-img" />
+          <span class="fw-bold text-green-1">목표 달성!</span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from "vue";
+import axios from "axios";
+import { useTransactionStore } from "@/stores/useTransactionStore";
+import dayjs from "dayjs";
+import smileIcon from "@/assets/icons/group/group-smile.png";
+
+// TODO: useUserStore 연결 후 실제 userId로 교체
+const DUMMY_USER_ID = "u1";
+
+const transactionStore = useTransactionStore();
+const goals = ref([]);
+const loading = ref(false);
+
+onMounted(async () => {
+  const now = dayjs();
+  loading.value = true;
+  try {
+    const [goalsRes] = await Promise.all([
+      axios.get("http://localhost:3000/goals", {
+        params: { userId: DUMMY_USER_ID },
+      }),
+      transactionStore.fetchMonthlyTransactions(
+        DUMMY_USER_ID,
+        now.year(),
+        now.month() + 1,
+      ),
+    ]);
+    goals.value = goalsRes.data;
+  } finally {
+    loading.value = false;
+  }
+});
+
+const netProfit = computed(() => {
+  const income = transactionStore.transactions
+    .filter((tx) => tx.type === "income")
+    .reduce((sum, tx) => sum + tx.amount, 0);
+  const expense = transactionStore.transactions
+    .filter((tx) => tx.type === "expense")
+    .reduce((sum, tx) => sum + tx.amount, 0);
+  return income - expense;
+});
+
+const goalsWithProgress = computed(() =>
+  goals.value.map((goal) => {
+    const rate = Math.min((netProfit.value / goal.targetAmount) * 100, 100);
+    return {
+      ...goal,
+      progressRate: Math.max(rate, 0),
+      achieved: netProfit.value >= goal.targetAmount,
+    };
+  }),
+);
+
+function formatAmount(amount) {
+  return `${amount.toLocaleString("ko-KR")}원`;
+}
+</script>
+
+<style scoped>
+.goal-chart {
+  padding: 28px 32px;
+}
+
+.section-title {
+  margin: 0 0 20px 0;
+  font-size: 16px;
+}
+
+.empty-msg {
+  font-size: 14px;
+  text-align: center;
+  padding: 24px 0;
+}
+
+.goal-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.goal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.goal-name {
+  font-size: 14px;
+}
+
+.goal-status {
+  font-size: 13px;
+}
+
+.bar-track {
+  width: 100%;
+  height: 10px;
+  background-color: var(--black-3);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+.celebrate {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.celebrate-img {
+  width: 20px;
+  height: 20px;
+}
+
+.celebrate span {
+  font-size: 13px;
+}
+</style>

--- a/src/pages/DashboardView.vue
+++ b/src/pages/DashboardView.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="dashboard">
     <SummaryCards />
+    <RecentTransactions />
+    <GoalChart />
   </div>
 </template>
 
 <script setup>
 import SummaryCards from "@/components/dashboard/SummaryCards.vue";
+import RecentTransactions from "@/components/dashboard/RecentTransactions.vue";
+import GoalChart from "@/components/dashboard/GoalChart.vue";
 </script>
 
 <style scoped>


### PR DESCRIPTION
  ## 1. 개요
  개인 목표 금액과 이번 달 순수익(총수입 - 총지출)을 비교해
  달성 여부를 가로 바 차트로 보여주는 컴포넌트를 구현합니다.

  ## 2. 주요 변경 사항
  - `GoalChart.vue`: 목표 달성 바 차트 컴포넌트 신규 구현
    - /goals API로 개인 목표 데이터 조회 (임시 userId: u1)
    - useTransactionStore에서 이번 달 순수익 계산 (총수입 - 총지출)
    - 순수익 vs 목표금액 비교로 달성/미달성 판단
    - 가로 바 차트 UI, 달성 시 초록색 바 + 축하 이미지 표시
  - `DashboardView.vue`: 확인용 임시 컴포넌트 연결

  ## 3. 리뷰 포인트
  - userId 임시값(u1) 하드코딩 — useUserStore 구현 후 교체 필요
  - DashboardView 컴포넌트 연결은 담당자가 최종 정리 필요