### PR TITLE
fix 대시보드 컴포넌트 임시 userId u1으로 수정

### DIFF
--- a/src/components/dashboard/RecentTransactions.vue
+++ b/src/components/dashboard/RecentTransactions.vue
@@ -40,7 +40,7 @@ import { useTransactionStore } from "@/stores/useTransactionStore";
 import dayjs from "dayjs";
 
 // TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = 1;
+const DUMMY_USER_ID = "u1";
 const RECENT_COUNT = 5;
 
 const transactionStore = useTransactionStore();

--- a/src/components/dashboard/SummaryCards.vue
+++ b/src/components/dashboard/SummaryCards.vue
@@ -21,7 +21,7 @@ import mainExpense from "@/assets/icons/main-page/main-expense.png";
 import mainProfit from "@/assets/icons/main-page/main-profit.png";
 
 // TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = 1;
+const DUMMY_USER_ID = "u1";
 
 const transactionStore = useTransactionStore();
 


### PR DESCRIPTION
  ## 1. 개요                                                                                                                                                               
  이전에 구현한 대시보드 컴포넌트의 임시 userId를 1에서 u1으로 수정합니다.                                                                                                 
                                                                                                                                                                           
  ## 2. 주요 변경 사항                                                                                                                                                     
  - `SummaryCards.vue`: DUMMY_USER_ID 1 → "u1" 수정                                                                                                                        
  - `RecentTransactions.vue`: DUMMY_USER_ID 1 → "u1" 수정                                                                                                                  
                                                                                                                                                                           
  ## 3. 리뷰 포인트
  - useUserStore 구현 완료 후 두 컴포넌트 모두 실제 userId로 교체 필요