### PR TITLE
chore db.json gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __screenshots__/
 
 # Vite
 *.timestamp-*-*.mjs
+
+# Local mock data
+db.json


### PR DESCRIPTION
  ## 1. 개요
  로컬 목 데이터인 db.json을 .gitignore에 추가합니다.                                                                                                                      
                                                            
  ## 2. 주요 변경 사항
  - `.gitignore`: db.json 추가

  ## 3. 리뷰 포인트
  - db.json은 각자 로컬에서 관리하는 목 데이터이므로 팀원 모두 로컬에 직접 생성 필요