### PR TITLE
feat TransactionList 수정/삭제 store 액션 연동

### DIFF
--- a/src/components/calendar/TransactionList.vue
+++ b/src/components/calendar/TransactionList.vue
@@ -91,7 +91,6 @@
 
 <script setup>
 import { ref, computed, onMounted } from "vue";
-import axios from "axios";
 import { useTransactionStore } from "@/stores/useTransactionStore";
 import dayjs from "dayjs";
 import arrowDown from "@/assets/icons/arrow-down.png";
@@ -145,22 +144,16 @@ function cancelEdit() {
 }
 
 async function submitEdit(id) {
-  await axios.patch(`http://localhost:3000/transactions/${id}`, {
+  await transactionStore.updateTransaction(id, {
     memo: editForm.value.memo,
     amount: editForm.value.amount,
   });
-  const tx = transactionStore.transactions.find((t) => t.id === id);
-  if (tx) {
-    tx.memo = editForm.value.memo;
-    tx.amount = editForm.value.amount;
-  }
   editingId.value = null;
   selectedId.value = null;
 }
 
 async function deleteTransaction(id) {
-  await axios.delete(`http://localhost:3000/transactions/${id}`);
-  transactionStore.transactions = transactionStore.transactions.filter((t) => t.id !== id);
+  await transactionStore.deleteTransaction(id);
   selectedId.value = null;
 }
 


### PR DESCRIPTION
#28

 ## 1. 개요                                                                                                                                                               
  TransactionList.vue에서 axios로 직접 처리하던 수정/삭제 로직을                                                                                                           
  useTransactionStore 액션으로 교체합니다.                                                                                                                                 
                                                                                                                                                                           
  ## 2. 주요 변경 사항                                                                                                                                                     
  - `TransactionList.vue`                                                                                                                                                  
    - submitEdit: axios.patch 직접 호출 → updateTransaction 액션으로 교체
    - deleteTransaction: axios.delete 직접 호출 → deleteTransaction 액션으로 교체
    - 불필요해진 axios import 제거

  ## 3. 리뷰 포인트
  - 관련 이슈: transaction-list, transaction-store-actions PR 머지 후 진행한 작업