### PR TITLE
refactor: 카테고리 공통 상수 파일 분리 (constants/categories.js)  

### DIFF
--- a/src/components/calendar/TransactionList.vue
+++ b/src/components/calendar/TransactionList.vue
@@ -103,30 +103,10 @@ import { ref, computed, onMounted } from "vue";
 import { useTransactionStore } from "@/stores/useTransactionStore";
 import dayjs from "dayjs";
 import iconHistory from "@/assets/icons/category/category-history.png";
-import iconFood from "@/assets/icons/category/category-food-black.png";
-import iconTrans from "@/assets/icons/category/category-trans-black.png";
-import iconShop from "@/assets/icons/category/category-shop-black.png";
-import iconCulture from "@/assets/icons/category/category-culture-black.png";
-import iconSalary from "@/assets/icons/category/category-salary-black.png";
-import iconPocket from "@/assets/icons/category/category-pocket-black.png";
-
-const CATEGORY_MAP = {
-  c1: { name: "급여", icon: iconSalary, type: "income" },
-  c2: { name: "용돈", icon: iconPocket, type: "income" },
-  c3: { name: "식비", icon: iconFood, type: "expense" },
-  c4: { name: "교통/통신", icon: iconTrans, type: "expense" },
-  c5: { name: "쇼핑", icon: iconShop, type: "expense" },
-  c6: { name: "문화/여가", icon: iconCulture, type: "expense" },
-};
-
-const CATEGORIES = Object.entries(CATEGORY_MAP).map(([id, val]) => ({ id, ...val }));
-
-function getCategoryInfo(categoryId) {
-  return CATEGORY_MAP[categoryId] ?? { name: categoryId, icon: null };
-}
+import { getCategoryInfo, getCategoriesByType } from "@/constants/categories";
 
 function filteredCategories(type) {
-  return CATEGORIES.filter((cat) => cat.type === type);
+  return getCategoriesByType(type);
 }
 
 // TODO: useUserStore 연결 후 실제 userId로 교체

--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -1,0 +1,28 @@
+import iconSalary from "@/assets/icons/category/category-salary-black.png";
+import iconPocket from "@/assets/icons/category/category-pocket-black.png";
+import iconFood from "@/assets/icons/category/category-food-black.png";
+import iconTrans from "@/assets/icons/category/category-trans-black.png";
+import iconShop from "@/assets/icons/category/category-shop-black.png";
+import iconCulture from "@/assets/icons/category/category-culture-black.png";
+
+export const CATEGORY_MAP = {
+  c1: { name: "급여", icon: iconSalary, type: "income" },
+  c2: { name: "용돈", icon: iconPocket, type: "income" },
+  c3: { name: "식비", icon: iconFood, type: "expense" },
+  c4: { name: "교통/통신", icon: iconTrans, type: "expense" },
+  c5: { name: "쇼핑", icon: iconShop, type: "expense" },
+  c6: { name: "문화/여가", icon: iconCulture, type: "expense" },
+};
+
+export const CATEGORIES = Object.entries(CATEGORY_MAP).map(([id, val]) => ({
+  id,
+  ...val,
+}));
+
+export function getCategoryInfo(categoryId) {
+  return CATEGORY_MAP[categoryId] ?? { name: categoryId, icon: null, type: null };
+}
+
+export function getCategoriesByType(type) {
+  return CATEGORIES.filter((cat) => cat.type === type);
+}


### PR DESCRIPTION
  ## 📄 PR 요약
  > `TransactionList.vue` 내부에 하드코딩되어 있던 `CATEGORY_MAP`을 공통 상수 모듈로 분리하여
  > 다른 컴포넌트(RecentTransactions 등)에서도 재사용할 수 있도록 리팩토링합니다.

  ## ✍🏻 PR 상세
  1. `src/constants/categories.js` 신규 생성
     - `CATEGORY_MAP`: categoryId(c1~c6)별 name, icon, type 매핑
     - `CATEGORIES`: 배열 형태 export (select 옵션 등에 활용)
     - `getCategoryInfo(categoryId)`: id로 카테고리 정보 조회
     - `getCategoriesByType(type)`: type으로 카테고리 필터링
  2. `TransactionList.vue`에서 내부 정의 제거 후 `constants/categories.js` import로 교체
     - 개별 아이콘 import 6개 및 유틸 함수 2개 제거

  ## 👀 참고사항
  - 이후 `RecentTransactions.vue`(Issue #6)에서 `getCategoryInfo`를 import하여 카테고리 아이콘 연동 예정
  - `TransactionList.vue`의 기존 동작에는 변경 없음 (빌드 및 런타임 검증 완료)

  ## ✅ 체크리스트
  - [x] PR 양식에 맞게 작성했습니다.
  - [x] 모든 테스트가 통과했습니다.
  - [x] 프로그램이 정상적으로 작동합니다.
  - [x] 적절한 라벨을 설정했습니다.
  - [x] 불필요한 코드를 제거했습니다.

  ## 🚪 연관된 이슈 번호
  #47 
