### PR TITLE
refactor : SummaryCards: auth/transaction store 연동 및 UI 개선

### DIFF
--- a/src/components/dashboard/SummaryCards.vue
+++ b/src/components/dashboard/SummaryCards.vue
@@ -6,8 +6,10 @@
       </div>
       <div class="card-content">
         <p class="card-label fw-medium text-black-2">{{ card.label }}</p>
-        <p v-if="transactionStore.loading" class="card-amount fw-bold text-black-2">불러오는 중...</p>
-        <p v-else class="card-amount fw-bold text-black-1">{{ formatAmount(card.value) }}</p>
+        <div v-if="transactionStore.loading" class="skeleton" />
+        <p v-else class="card-amount fw-bold" :class="card.amountClass">
+          {{ formatAmount(card.value) }}
+        </p>
       </div>
     </div>
   </div>
@@ -54,18 +56,21 @@ const cards = computed(() => [
     value: totalIncome.value,
     bgClass: "bg-green-2",
     icon: mainIncome,
+    amountClass: "text-income",
   },
   {
     label: "총 지출",
     value: totalExpense.value,
     bgClass: "bg-red-2",
     icon: mainExpense,
+    amountClass: "text-expense",
   },
   {
     label: "순수익",
     value: netProfit.value,
     bgClass: "bg-blue-1",
     icon: mainProfit,
+    amountClass: netProfit.value >= 0 ? "text-income" : "text-expense",
   },
 ]);
 
@@ -115,5 +120,36 @@ function formatAmount(amount) {
 .card-amount {
   margin: 0;
   font-size: 20px;
+}
+
+.text-income {
+  color: #1a7a6e;
+}
+
+.text-expense {
+  color: var(--red-1);
+}
+
+.skeleton {
+  width: 100px;
+  height: 24px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--black-3) 25%,
+    var(--black-4) 50%,
+    var(--black-3) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 </style>

--- a/src/components/dashboard/SummaryCards.vue
+++ b/src/components/dashboard/SummaryCards.vue
@@ -6,7 +6,8 @@
       </div>
       <div class="card-content">
         <p class="card-label fw-medium text-black-2">{{ card.label }}</p>
-        <p class="card-amount fw-bold text-black-1">{{ formatAmount(card.value) }}</p>
+        <p v-if="transactionStore.loading" class="card-amount fw-bold text-black-2">불러오는 중...</p>
+        <p v-else class="card-amount fw-bold text-black-1">{{ formatAmount(card.value) }}</p>
       </div>
     </div>
   </div>
@@ -15,20 +16,19 @@
 <script setup>
 import { computed, onMounted } from "vue";
 import { useTransactionStore } from "@/stores/useTransactionStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 import dayjs from "dayjs";
 import mainIncome from "@/assets/icons/main-page/main-income.png";
 import mainExpense from "@/assets/icons/main-page/main-expense.png";
 import mainProfit from "@/assets/icons/main-page/main-profit.png";
 
-// TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = "u1";
-
+const authStore = useAuthStore();
 const transactionStore = useTransactionStore();
 
 onMounted(async () => {
   const now = dayjs();
   await transactionStore.fetchMonthlyTransactions(
-    DUMMY_USER_ID,
+    authStore.currentUserId,
     now.year(),
     now.month() + 1,
   );


### PR DESCRIPTION
  ## 📄 PR 요약
  > `SummaryCards.vue`의 하드코딩된 더미 userId를 제거하고 실제 로그인 유저 기반으로
  > 이번 달 수입/지출/순수익 데이터를 표시하도록 연동합니다.
  > 아울러 loading skeleton 및 금액 색상 구분 UI를 적용합니다.

  ## ✍🏻 PR 상세
  1. `useAuthStore.currentUserId`로 `DUMMY_USER_ID` 교체 및 실제 유저 데이터 fetch
  2. `transactionStore.loading` 중 shimmer skeleton 애니메이션 표시
  3. 금액 색상 구분 적용
     - 수입: 초록 / 지출: 빨강
     - 순수익: 양수 → 초록, 음수 → 빨강

  ## 👀 참고사항
  - 로그인 유저(u1, u2, u4) 전환 시 각자의 이번 달 데이터가 올바르게 표시됨

  ## ✅ 체크리스트
  - [x] `DUMMY_USER_ID` 코드가 제거되었다.
  - [x] 로그인 유저에 따라 이번 달 수입 / 지출 / 순수익이 올바르게 표시된다.
  - [x] 데이터 로딩 중 skeleton 애니메이션이 표시된다.
  - [x] 순수익이 양수일 때 초록, 음수일 때 빨강으로 표시된다.

  ## 🚪 연관된 이슈 번호
  #49
  #50