### PR TITLE
refactor : GoalChart: auth store 연동 및 UI 개선

### DIFF
--- a/src/components/dashboard/GoalChart.vue
+++ b/src/components/dashboard/GoalChart.vue
@@ -38,12 +38,11 @@
 import { ref, computed, onMounted } from "vue";
 import axios from "axios";
 import { useTransactionStore } from "@/stores/useTransactionStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 import dayjs from "dayjs";
 import smileIcon from "@/assets/icons/group/group-smile.png";
 
-// TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = "u1";
-
+const authStore = useAuthStore();
 const transactionStore = useTransactionStore();
 const goals = ref([]);
 const loading = ref(false);
@@ -53,11 +52,11 @@ onMounted(async () => {
   loading.value = true;
   try {
     const [goalsRes] = await Promise.all([
-      axios.get("http://localhost:3000/goals", {
-        params: { userId: DUMMY_USER_ID },
+      axios.get("/api/goals", {
+        params: { userId: authStore.currentUserId },
       }),
       transactionStore.fetchMonthlyTransactions(
-        DUMMY_USER_ID,
+        authStore.currentUserId,
         now.year(),
         now.month() + 1,
       ),

--- a/src/components/dashboard/GoalChart.vue
+++ b/src/components/dashboard/GoalChart.vue
@@ -2,32 +2,36 @@
   <div class="goal-chart box-default">
     <h2 class="section-title fw-bold text-black-1">목표 달성</h2>
 
-    <div v-if="loading" class="empty-msg text-black-2">불러오는 중...</div>
+    <div v-if="loading" class="skeleton-wrap">
+      <div class="skeleton skeleton-title" />
+      <div class="skeleton skeleton-bar" />
+    </div>
 
-    <div v-else-if="goals.length === 0" class="empty-msg text-black-2">
-      등록된 목표가 없습니다.
+    <div v-else-if="goals.length === 0" class="empty-state">
+      <p class="empty-msg text-black-2">아직 등록된 목표가 없어요.</p>
+      <p class="empty-sub text-black-2">프로필에서 목표를 설정해보세요!</p>
     </div>
 
     <ul v-else class="goal-list">
       <li v-for="goal in goalsWithProgress" :key="goal.id" class="goal-item">
         <div class="goal-header">
           <span class="goal-name fw-medium text-black-1">{{ goal.itemName }}</span>
-          <span class="goal-status fw-semibold" :class="goal.achieved ? 'text-green-1' : 'text-black-2'">
-            {{ goal.achieved ? "달성" : `${formatAmount(netProfit)} / ${formatAmount(goal.targetAmount)}` }}
+          <span class="goal-amount fw-semibold" :class="goal.achieved ? 'text-achieved' : 'text-black-2'">
+            {{ goal.achieved ? "달성 완료!" : `${formatAmount(netProfit)} / ${formatAmount(goal.targetAmount)}` }}
           </span>
         </div>
 
         <div class="bar-track">
           <div
             class="bar-fill"
-            :class="goal.achieved ? 'bg-green-1' : 'bg-yellow-1'"
+            :class="goal.achieved ? 'bar-achieved' : 'bar-progress'"
             :style="{ width: `${goal.progressRate}%` }"
-          ></div>
+          />
         </div>
 
         <div v-if="goal.achieved" class="celebrate">
           <img :src="smileIcon" alt="달성 축하" class="celebrate-img" />
-          <span class="fw-bold text-green-1">목표 달성!</span>
+          <span class="fw-bold text-achieved">목표 달성!</span>
         </div>
       </li>
     </ul>
@@ -103,12 +107,60 @@ function formatAmount(amount) {
   font-size: 16px;
 }
 
-.empty-msg {
-  font-size: 14px;
-  text-align: center;
+/* skeleton */
+.skeleton-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeleton {
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--black-3) 25%,
+    var(--black-4) 50%,
+    var(--black-3) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-title {
+  width: 40%;
+  height: 16px;
+}
+
+.skeleton-bar {
+  width: 100%;
+  height: 12px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* empty state */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   padding: 24px 0;
 }
 
+.empty-msg {
+  margin: 0;
+  font-size: 14px;
+}
+
+.empty-sub {
+  margin: 0;
+  font-size: 12px;
+}
+
+/* goal list */
 .goal-list {
   list-style: none;
   padding: 0;
@@ -122,20 +174,25 @@ function formatAmount(amount) {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .goal-name {
   font-size: 14px;
 }
 
-.goal-status {
+.goal-amount {
   font-size: 13px;
 }
 
+.text-achieved {
+  color: #1a7a6e;
+}
+
+/* progress bar */
 .bar-track {
   width: 100%;
-  height: 10px;
+  height: 12px;
   background-color: var(--black-3);
   border-radius: 999px;
   overflow: hidden;
@@ -147,16 +204,28 @@ function formatAmount(amount) {
   transition: width 0.4s ease;
 }
 
+.bar-progress {
+  background-color: var(--yellow-1);
+}
+
+.bar-achieved {
+  background-color: var(--green-1);
+}
+
+/* celebrate */
 .celebrate {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 8px;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  background-color: var(--green-3);
+  border-radius: 8px;
 }
 
 .celebrate-img {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
 }
 
 .celebrate span {


### PR DESCRIPTION
  ## 📄 PR 요약
  > `GoalChart.vue`의 하드코딩된 더미 userId를 제거하고 실제 로그인 유저 기반으로
  > 목표 및 거래 데이터를 표시하도록 연동합니다.
  > 아울러 skeleton loading, empty state, 달성 UI를 개선합니다.

  ## ✍🏻 PR 상세
  1. `useAuthStore.currentUserId`로 `DUMMY_USER_ID` 교체
     - goals fetch 및 `fetchMonthlyTransactions` 호출 시 실제 userId 사용
     - axios URL을 절대경로(`http://localhost:3000`)에서 프록시 경로(`/api`)로 변경
  2. UI 개선
     - loading 중 shimmer skeleton 애니메이션 적용 (제목 + 바 형태)
     - 목표 없을 때 empty state 안내 문구 표시
     - progress bar 높이(10px → 12px) 및 달성/미달성 색상 분리
     - 달성 시 celebrate 영역 배경색 추가로 강조

  ## 👀 참고사항
  - `useUserStore.loadUserGoalData`는 첫 번째 목표 1개만 저장하므로
    전체 목표 목록 표시를 위해 axios 직접 호출 방식 유지

  ## ✅ 체크리스트
  - [x] `DUMMY_USER_ID` 코드가 제거되었다.
  - [x] 로그인 유저의 목표가 올바르게 표시된다.
  - [x] 데이터 로딩 중 skeleton 애니메이션이 표시된다.
  - [x] 목표가 없을 때 empty state 안내 문구가 표시된다.
  - [x] 미달성 시 노란 progress bar가 표시된다.
  - [x] 달성 시 초록 progress bar 및 celebrate 영역이 표시된다.

  ## 🚪 연관된 이슈 번호
  Closes #54 
  Closes #55 