### PR TITLE
 refactor : RecentTransactions: store 연동 및 UI 개선  

### DIFF
--- a/src/components/dashboard/RecentTransactions.vue
+++ b/src/components/dashboard/RecentTransactions.vue
@@ -22,8 +22,7 @@
       <tbody>
         <tr v-for="tx in recentTransactions" :key="tx.id">
           <td class="fw-regular text-black-2">{{ formatDate(tx.date) }}</td>
-          <!-- TODO: categoryId → 카테고리명 변환 (카테고리 store/API 연동 후 교체) -->
-          <td class="fw-regular text-black-2">{{ tx.categoryId }}</td>
+          <td class="fw-regular text-black-2">{{ getCategoryInfo(tx.categoryId).name }}</td>
           <td class="fw-semibold" :class="tx.type === 'income' ? 'text-green-1' : 'text-red-1'">
             {{ formatAmount(tx.type, tx.amount) }}
           </td>
@@ -37,18 +36,19 @@
 <script setup>
 import { computed, onMounted } from "vue";
 import { useTransactionStore } from "@/stores/useTransactionStore";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { getCategoryInfo } from "@/constants/categories";
 import dayjs from "dayjs";
 
-// TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = "u1";
 const RECENT_COUNT = 5;
 
+const authStore = useAuthStore();
 const transactionStore = useTransactionStore();
 
 onMounted(async () => {
   const now = dayjs();
   await transactionStore.fetchMonthlyTransactions(
-    DUMMY_USER_ID,
+    authStore.currentUserId,
     now.year(),
     now.month() + 1,
   );

--- a/src/components/dashboard/RecentTransactions.vue
+++ b/src/components/dashboard/RecentTransactions.vue
@@ -1,35 +1,49 @@
 <template>
   <div class="recent-transactions box-default">
-    <h2 class="section-title fw-bold text-black-1">최근 거래 내역</h2>
+    <div class="header">
+      <div class="header-left">
+        <img :src="iconHistory" class="header-icon" alt="최근 거래" />
+        <h2 class="section-title fw-bold text-black-1">최근 거래 내역</h2>
+      </div>
+      <router-link to="/transactions" class="more-link fw-medium text-black-2">
+        더보기 &gt;
+      </router-link>
+    </div>
 
-    <div v-if="transactionStore.loading" class="empty-msg text-black-2">
-      불러오는 중...
+    <div v-if="transactionStore.loading" class="skeleton-wrap">
+      <div v-for="n in 5" :key="n" class="skeleton-row">
+        <div class="skeleton skeleton-icon" />
+        <div class="skeleton-info">
+          <div class="skeleton skeleton-memo" />
+          <div class="skeleton skeleton-date" />
+        </div>
+        <div class="skeleton skeleton-amount" />
+      </div>
     </div>
 
     <div v-else-if="recentTransactions.length === 0" class="empty-msg text-black-2">
       이번 달 거래 내역이 없습니다.
     </div>
 
-    <table v-else class="tx-table">
-      <thead>
-        <tr>
-          <th class="fw-semibold text-black-2">날짜</th>
-          <th class="fw-semibold text-black-2">카테고리</th>
-          <th class="fw-semibold text-black-2">금액</th>
-          <th class="fw-semibold text-black-2">메모</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="tx in recentTransactions" :key="tx.id">
-          <td class="fw-regular text-black-2">{{ formatDate(tx.date) }}</td>
-          <td class="fw-regular text-black-2">{{ getCategoryInfo(tx.categoryId).name }}</td>
-          <td class="fw-semibold" :class="tx.type === 'income' ? 'text-green-1' : 'text-red-1'">
-            {{ formatAmount(tx.type, tx.amount) }}
-          </td>
-          <td class="fw-regular text-black-2">{{ tx.memo ?? "-" }}</td>
-        </tr>
-      </tbody>
-    </table>
+    <ul v-else class="tx-list">
+      <li v-for="tx in recentTransactions" :key="tx.id" class="tx-item">
+        <div class="tx-icon-wrap">
+          <img
+            v-if="getCategoryInfo(tx.categoryId).icon"
+            :src="getCategoryInfo(tx.categoryId).icon"
+            :alt="getCategoryInfo(tx.categoryId).name"
+            class="category-icon"
+          />
+        </div>
+        <div class="tx-info">
+          <span class="tx-memo fw-semibold text-black-1">{{ tx.memo ?? "-" }}</span>
+          <span class="tx-date fw-regular text-black-2">{{ formatDate(tx.date) }}</span>
+        </div>
+        <span class="tx-amount fw-bold" :class="tx.type === 'income' ? 'text-income' : 'text-expense'">
+          {{ formatAmount(tx.type, tx.amount) }}
+        </span>
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -39,6 +53,7 @@ import { useTransactionStore } from "@/stores/useTransactionStore";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { getCategoryInfo } from "@/constants/categories";
 import dayjs from "dayjs";
+import iconHistory from "@/assets/icons/category/category-history.png";
 
 const RECENT_COUNT = 5;
 
@@ -61,12 +76,12 @@ const recentTransactions = computed(() => {
 });
 
 function formatDate(date) {
-  return dayjs(date).format("MM.DD");
+  return dayjs(date).format("YYYY. MM. DD");
 }
 
 function formatAmount(type, amount) {
   const sign = type === "income" ? "+" : "-";
-  return `${sign}${amount.toLocaleString("ko-KR")}원`;
+  return `${sign}${amount.toLocaleString("ko-KR")}`;
 }
 </script>
 
@@ -75,35 +90,167 @@ function formatAmount(type, amount) {
   padding: 28px 32px;
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header-icon {
+  width: 18px;
+  height: 18px;
+  opacity: 0.5;
+}
+
 .section-title {
-  margin: 0 0 20px 0;
+  margin: 0;
   font-size: 16px;
 }
 
+.more-link {
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.more-link:hover {
+  color: var(--black-1);
+}
+
+/* skeleton */
+.skeleton-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.skeleton-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeleton {
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--black-3) 25%,
+    var(--black-4) 50%,
+    var(--black-3) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-memo {
+  width: 60%;
+  height: 14px;
+}
+
+.skeleton-date {
+  width: 40%;
+  height: 12px;
+}
+
+.skeleton-amount {
+  width: 60px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* empty */
 .empty-msg {
   font-size: 14px;
   text-align: center;
   padding: 24px 0;
 }
 
-.tx-table {
-  width: 100%;
-  border-collapse: collapse;
+/* tx list */
+.tx-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
-.tx-table th,
-.tx-table td {
-  padding: 12px 8px;
-  font-size: 14px;
-  text-align: left;
+.tx-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
 }
 
-.tx-table th {
+.tx-item:hover .tx-memo {
+  opacity: 0.7;
+}
+
+.tx-icon-wrap {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.category-icon {
+  width: 24px;
+  height: 24px;
+  opacity: 0.6;
+}
+
+.tx-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tx-memo {
+  font-size: 15px;
+}
+
+.tx-date {
   font-size: 12px;
-  border-bottom: 1px solid var(--black-3);
 }
 
-.tx-table tbody tr + tr {
-  border-top: 1px solid var(--black-3);
+.tx-amount {
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.text-income {
+  color: #1a7a6e;
+}
+
+.text-expense {
+  color: var(--red-1);
 }
 </style>


### PR DESCRIPTION
  ## 📄 PR 요약                                                                                                                                                                                                           
  > `RecentTransactions.vue`의 하드코딩된 더미 userId를 제거하고 실제 로그인 유저 기반으로
  > 거래 데이터를 표시하도록 연동합니다.
  > 카테고리 아이콘을 적용하고 디자인 시안 기반으로 table 구조를 list 형태로 교체합니다.

  ## ✍🏻 PR 상세
  1. `useAuthStore.currentUserId`로 `DUMMY_USER_ID` 교체 및 TODO 주석 제거
  2. `constants/categories.js`의 `getCategoryInfo` import하여 카테고리 아이콘 + 이름 표시
  3. table 구조 → list 구조로 교체
     - 헤더: 히스토리 아이콘 + "최근 거래 내역" + 우측 "더보기 >" 링크(/transactions)
     - 각 항목: 카테고리 아이콘 | 메모(bold) + 날짜(YYYY. MM. DD) | 금액(+/- comma 포맷)
     - 수입: 초록 / 지출: 빨강 색상 적용
  4. loading 중 shimmer skeleton 적용

  ## 👀 참고사항
  - `constants/categories.js`는 `refactor/category-constants` PR 기준 (merge 선행 필요)

  ## ✅ 체크리스트
  - [x] `DUMMY_USER_ID` 코드가 제거되었다.
  - [x] 로그인 유저의 최근 5건 거래가 날짜 내림차순으로 표시된다.
  - [x] 각 항목에 카테고리 아이콘이 정상 표시된다.
  - [x] 날짜가 `YYYY. MM. DD` 형식으로 표시된다.
  - [x] 금액이 `+50,000` / `-20,000` 형식으로 표시된다.
  - [x] 수입은 초록, 지출은 빨강 색상으로 표시된다.
  - [x] 데이터 로딩 중 skeleton 애니메이션이 표시된다.
  - [x] 거래가 없을 때 empty state 문구가 표시된다.
  - [x] "더보기 >" 클릭 시 `/transactions` 페이지로 이동한다.

  ## 🚪 연관된 이슈 번호
  Closes #57
