### PR TITLE
design: 전체 페이지 모바일 레이아웃 디자인

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,30 +1,7 @@
 <template>
-  <div class="container">
-    <SideBar></SideBar>
-    <section class="router-container">
-      <router-view></router-view>
-    </section>
-  </div>
+  <MainLayout />
 </template>
 
 <script setup>
-import SideBar from './components/common/SideBar.vue'
+import MainLayout from './layouts/MainLayout.vue'
 </script>
-
-<style scoped>
-.container {
-  width: 100%;
-  height: 100vh;
-  background-color: #f9fafa;
-  padding: 0;
-
-  display: flex;
-}
-
-.router-container {
-  width: calc(100% - 320px);
-  height: 100%;
-  padding: 72px 48px;
-  box-sizing: border-box;
-}
-</style>

--- a/src/components/common/BottomBar.vue
+++ b/src/components/common/BottomBar.vue
@@ -1,0 +1,24 @@
+<template>
+  <nav class="bottom-bar box-default">
+    <MenuList />
+  </nav>
+</template>
+
+<script setup>
+import MenuList from './sidebar/MenuList.vue'
+</script>
+
+<style scoped>
+.bottom-bar {
+  width: 100%;
+  height: 60px;
+  background-color: white;
+  border-radius: 0;
+  padding: 8px;
+  box-sizing: border-box;
+
+  position: fixed;
+  left: 0;
+  bottom: 0;
+}
+</style>

--- a/src/components/common/TopBar.vue
+++ b/src/components/common/TopBar.vue
@@ -1,0 +1,43 @@
+<template>
+  <header class="top-bar box-default">
+    <div class="logo-button">
+      <img :src="LogoImage" :width="isMobile ? 167 : 209" :height="isMobile ? 32 : 40" />
+      <router-link to="/add"><AddButton /></router-link>
+    </div>
+    <router-link to="/profile"><ProfileCard /></router-link>
+  </header>
+</template>
+
+<script setup>
+import LogoImage from '@/assets/icons/sidebar/sidebar-logo.png'
+import AddButton from './sidebar/AddButton.vue'
+import { inject } from 'vue'
+import ProfileCard from './sidebar/ProfileCard.vue'
+
+const isMobile = inject('isMobile')
+</script>
+
+<style scoped>
+.top-bar {
+  width: 100%;
+  height: fit-content;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+
+  padding: 20px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.logo-button {
+  width: 100%;
+  height: fit-content;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/src/components/common/sidebar/AddButton.vue
+++ b/src/components/common/sidebar/AddButton.vue
@@ -1,12 +1,15 @@
 <template>
   <button>
     <img :src="LogoImage" width="15" height="15" />
-    <span class="text-blue-1 fw-bold">내역 추가하기</span>
+    <span class="text-blue-1 fw-bold">{{ isMobile ? '추가' : '내역 추가하기' }}</span>
   </button>
 </template>
 
 <script setup>
 import LogoImage from '@/assets/icons/plus-blue.png'
+import { inject } from 'vue'
+
+const isMobile = inject('isMobile')
 </script>
 
 <style scoped>
@@ -29,5 +32,14 @@ button:hover {
 
 span {
   font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  button {
+    width: 72px;
+    height: 40px;
+    gap: 8px;
+    border-radius: 14px;
+  }
 }
 </style>

--- a/src/components/common/sidebar/MenuItem.vue
+++ b/src/components/common/sidebar/MenuItem.vue
@@ -3,8 +3,8 @@
     <li :class="currentRoute.fullPath === routeName[id] ? 'selected' : 'non-selected'">
       <img
         :src="currentRoute.fullPath === routeName[id] ? blackIcons[id] : icons[id]"
-        width="20"
-        height="20"
+        :width="isMobile ? 16 : 20"
+        :height="isMobile ? 16 : 20"
       />
       <span>{{ menuLabel[id] }}</span>
     </li>
@@ -21,6 +21,7 @@ import SummaryIcon from '@/assets/icons/sidebar/sidebar-summary.png'
 import GroupIconBlack from '@/assets/icons/sidebar/sidebar-race-black.png'
 import GroupIcon from '@/assets/icons/sidebar/sidebar-race.png'
 import { useRoute } from 'vue-router'
+import { inject } from 'vue'
 
 const menuLabel = ['메인 대시보드', '거래 내역 조회', '월별 재정 요약', '소비 레이스']
 const blackIcons = [MainIconBlack, TransIconBlack, SummaryIconBlack, GroupIconBlack]
@@ -32,6 +33,8 @@ const { id } = defineProps({
 })
 
 const currentRoute = useRoute()
+
+const isMobile = inject('isMobile')
 </script>
 
 <style scoped>
@@ -73,5 +76,21 @@ li {
 .non-selected span {
   color: var(--black-2);
   font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  li {
+    width: 100%;
+    height: 44px;
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    gap: 4px;
+    justify-content: center;
+  }
+
+  span {
+    font-size: 12px;
+  }
 }
 </style>

--- a/src/components/common/sidebar/MenuList.vue
+++ b/src/components/common/sidebar/MenuList.vue
@@ -16,4 +16,12 @@ ul {
   margin: 0;
   padding: 0;
 }
+
+@media (max-width: 768px) {
+  ul {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    column-gap: 8px;
+  }
+}
 </style>

--- a/src/components/common/sidebar/ProfileCard.vue
+++ b/src/components/common/sidebar/ProfileCard.vue
@@ -50,4 +50,39 @@ p {
 .hello {
   font-size: 16px;
 }
+
+@media (max-width: 768px) {
+  .profile-card {
+    width: 100%;
+    height: 108px;
+    display: grid;
+    padding: 16px;
+    box-sizing: border-box;
+
+    grid-template-columns: 80px 1fr;
+    grid-template-rows: 1fr 1fr;
+    row-gap: 8px;
+    column-gap: 12px;
+  }
+
+  .profile-image {
+    width: 76px;
+    height: 76px;
+    margin-bottom: 0;
+    font-size: 44px;
+
+    grid-row: 1 / 3;
+    grid-column: 1;
+  }
+
+  .name {
+    font-size: 18px;
+    align-self: end;
+  }
+
+  .hello {
+    font-size: 14px;
+    align-self: start;
+  }
+}
 </style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="container" :class="{ mobile: isMobile }">
+    <SideBar v-if="!isMobile" />
+    <TopBar v-if="isMobile" />
+    <section class="router-container" :class="{ mobile: isMobile }">
+      <router-view></router-view>
+    </section>
+    <BottomBar v-if="isMobile" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, provide } from 'vue'
+
+import SideBar from '@/components/common/SideBar.vue'
+import TopBar from '@/components/common/TopBar.vue'
+import BottomBar from '@/components/common/BottomBar.vue'
+
+const isMobile = ref(false)
+
+const mediaQuery = window.matchMedia('(max-width: 768px)')
+
+const check = (e) => {
+  isMobile.value = e.matches
+}
+
+onMounted(() => {
+  isMobile.value = mediaQuery.matches
+  mediaQuery.addEventListener('change', check)
+})
+
+onUnmounted(() => {
+  mediaQuery.removeEventListener('change', check)
+})
+
+provide('isMobile', isMobile)
+</script>
+
+<style scoped>
+.container {
+  width: 100%;
+  min-height: 100dvh;
+  background-color: #f9fafa;
+  padding: 0;
+
+  display: flex;
+}
+
+.container.mobile {
+  flex-direction: column;
+}
+
+.router-container {
+  width: calc(100% - 320px);
+  height: 100%;
+  padding: 72px 48px;
+  box-sizing: border-box;
+}
+
+.router-container.mobile {
+  width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  padding-top: 24px;
+  padding-bottom: 76px;
+}
+</style>


### PR DESCRIPTION
## 📄 PR 요약
> 데스크탑의 사이드 바를 TopBar와 BottomBar로 나눴습니다

## ✍🏻 PR 상세
1. 기존 사이드 바의 프로필, 거래 내역 추가, 로고를 상단 TopBar로 이동했습니다
2. 메뉴 네비게이션을 fixed로 하단에 고정된 BottomBar로 이동했습니다
3. App.vue에 있던 프로젝트 기본 레이아웃을 MainLayout으로 옮겼습니다

## 👀 참고사항
- MainLayout.vue에 현재 width에 모바일인지 확인할 수 있는 변수 isMobile을 provide 처리 해 뒀으니, 앞으로 반응형 개발할 때 inject로 해당 변수 가져와서 쓰면 됩니당

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #47
