### PR TITLE
feat: 필터바 '월 전체 조회' 모드 기능 및 달력 양방향 연동 구현

### DIFF
--- a/src/components/calendar/CalendarGrid.vue
+++ b/src/components/calendar/CalendarGrid.vue
@@ -17,7 +17,7 @@
         :class="[
           'day-cell',
           { 'not-current-month': !day.isCurrentMonth },
-          { 'selected-day': day.fullDate === store.selectedDate },
+          { 'selected-day': day.fullDate === store.selectedDate && !store.isMonthView },
         ]"
         @click="selectDate(day.fullDate)"
       >
@@ -88,6 +88,7 @@ const selectDate = (dateString) => {
   const newMonth = dayjs(dateString).month()
 
   store.setSelectedDate(dateString)
+  store.isMonthView = false
 
   if (oldMonth !== newMonth) {
     const year = dayjs(dateString).year()

--- a/src/components/calendar/FilterBar.vue
+++ b/src/components/calendar/FilterBar.vue
@@ -12,6 +12,8 @@
       </button>
     </div>
 
+    <button class="month-all-btn box-shadow-sm" @click="handleMonthView">월 거래 내역 조회</button>
+
     <div class="filter-group">
       <div class="filter-icon-box bg-black-4 justify-align box-shadow-sm">
         <img src="@/assets/icons/filter.png" alt="필터" class="filter-icon" />
@@ -51,13 +53,28 @@ const store = useTransactionStore()
 // 1. 월 이동
 const currentMonthText = computed(() => dayjs(store.selectedDate).format('YYYY / M'))
 
-const prevMonth = () => updateMonth(dayjs(store.selectedDate).subtract(1, 'month').startOf('month'))
-const nextMonth = () => updateMonth(dayjs(store.selectedDate).add(1, 'month').startOf('month'))
+const prevMonth = () =>
+  updateMonth(
+    dayjs(store.selectedDate).subtract(1, 'month').startOf('month'),
+    (store.isMonthView = true),
+  )
+
+const nextMonth = () =>
+  updateMonth(
+    dayjs(store.selectedDate).add(1, 'month').startOf('month'),
+    (store.isMonthView = true),
+  )
 
 const updateMonth = (newDateObj) => {
   const newDateStr = newDateObj.format('YYYY-MM-DD')
   store.setSelectedDate(newDateStr)
   store.fetchMonthlyTransactions('u1', newDateObj.year(), newDateObj.month() + 1)
+}
+
+const handleMonthView = () => {
+  store.isMonthView = true
+
+  store.selectedDate = null
 }
 
 // 필터 로직
@@ -94,7 +111,7 @@ const handleTypeChange = () => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 40px;
+  padding: 16px 45px;
   height: 80px;
   box-sizing: border-box;
 }
@@ -121,14 +138,16 @@ const handleTypeChange = () => {
 }
 .current-month {
   font-size: 20px;
-  width: 90px;
+  width: 110px;
   text-align: center;
+  white-space: nowrap;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
   gap: 12px;
+  margin-left: 10px;
 }
 .filter-icon-box {
   width: 40px;
@@ -142,7 +161,7 @@ const handleTypeChange = () => {
 
 .custom-select {
   height: 40px;
-  padding: 0 32px;
+  padding: 0 40px;
   border: 1px solid var(--black-4);
   border-radius: 12px;
   appearance: none;
@@ -162,5 +181,30 @@ const handleTypeChange = () => {
 
 .box-shadow-sm {
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.month-all-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 35px;
+  margin-left: 8px;
+
+  background-color: var(--yellow-1);
+  color: var(--black-1);
+
+  font-weight: 700;
+  font-size: 14px;
+  white-space: nowrap;
+
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.month-all-btn:hover {
+  opacity: 0.8;
 }
 </style>

--- a/src/components/calendar/FilterBar.vue
+++ b/src/components/calendar/FilterBar.vue
@@ -51,7 +51,7 @@ import dayjs from 'dayjs'
 const store = useTransactionStore()
 
 // 1. 월 이동
-const currentMonthText = computed(() => dayjs(store.selectedDate).format('YYYY / M'))
+const currentMonthText = computed(() => dayjs(store.selectedDate).format('YYYY년 M월'))
 
 const prevMonth = () =>
   updateMonth(
@@ -73,8 +73,6 @@ const updateMonth = (newDateObj) => {
 
 const handleMonthView = () => {
   store.isMonthView = true
-
-  store.selectedDate = null
 }
 
 // 필터 로직
@@ -111,7 +109,7 @@ const handleTypeChange = () => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 45px;
+  padding: 16px 40px;
   height: 80px;
   box-sizing: border-box;
 }
@@ -138,7 +136,7 @@ const handleTypeChange = () => {
 }
 .current-month {
   font-size: 20px;
-  width: 110px;
+  width: 120px;
   text-align: center;
   white-space: nowrap;
 }
@@ -188,7 +186,7 @@ const handleTypeChange = () => {
   align-items: center;
   justify-content: center;
   height: 40px;
-  padding: 0 35px;
+  padding: 0 30px;
   margin-left: 8px;
 
   background-color: var(--yellow-1);

--- a/src/stores/useTransactionStore.js
+++ b/src/stores/useTransactionStore.js
@@ -13,6 +13,7 @@ export const useTransactionStore = defineStore('transaction', {
     rangeLoading: false,
     filterType: 'all',
     filterCategory: 'all',
+    isMonthView: true,
   }),
 
   getters: {
@@ -45,8 +46,13 @@ export const useTransactionStore = defineStore('transaction', {
       }, {})
     },
 
-    // 선택된 날짜 필터링
+    // 날짜 필터링
     dailyTransactions(state) {
+      // 월 전체 조회
+      if (state.isMonthView) {
+        return this.filteredTransactions
+      }
+
       return this.filteredTransactions.filter(
         (tx) => dayjs(tx.date).format('YYYY-MM-DD') === state.selectedDate,
       )


### PR DESCRIPTION
## 📄 PR 요약
> 기존 일별 조회만 가능했던 거래 내역 리스트에 **'월 전체 조회'** 기능을 추가하여 사용성을 대폭 개선했습니다.
> FilterBar의 UI 개편과 함께 Pinia 상태 관리(`isMonthView`)를 도입하여, 달력과 리스트가 완벽하게 양방향으로 상호작용하도록 로직을 구현했습니다.

## ✍🏻 PR 상세 내역

**1. FilterBar UI/UX 개선**
- '월 거래 내역 조회' 버튼을 추가하고, Flexbox `justify-content: space-between`을 활용해 [월 네비게이션] - [월 조회 버튼] - [우측 필터] 형태의 3등분 중앙 정렬 레이아웃 적용.
- 10~12월 등 두 자리 숫자 렌더링 시 레이아웃이 깨지지 않도록 `white-space: nowrap` 추가.

**2. 스토어(Pinia) 상태 기반 필터링 분기**
- `useTransactionStore`에 `isMonthView` 상태값 추가 (기본값: true).
- `dailyTransactions` Getter를 업그레이드하여, 월 전체 모드일 때는 해당 월 전체 데이터를, 특정 일자 모드일 때는 `selectedDate`와 일치하는 데이터만 반환하도록 필터링 적용.

**3. 달력(Calendar) 하이라이트 조건 및 양방향 연동**
- 사용자가 달력에서 특정 날짜를 클릭하면 즉시 `isMonthView = false`로 전환되며 해당 일자 내역만 렌더링 되도록 UX 개선.

## ✅ 체크리스트
- [ ] 필터바 중앙에 '월 거래 내역 조회' 버튼이 예쁘게 3등분 정렬되어 있다.
- [ ] 페이지 최초 진입 또는 달력 화살표(</>) 이동 시 해당 월의 전체 내역이 리스트에 잘 뜬다.

## 🚪 연관된 이슈 번호
Closes #61