### PR TITLE
refactor: isMonthView 연동으로 isFiltered 분기 제거 및 단순화

### DIFF
--- a/src/components/calendar/TransactionList.vue
+++ b/src/components/calendar/TransactionList.vue
@@ -126,13 +126,10 @@ onMounted(async () => {
   );
 });
 
-const isFiltered = computed(() => !!transactionStore.selectedDate);
-
 const displayedTransactions = computed(() => {
-  const list = isFiltered.value
-    ? transactionStore.dailyTransactions
-    : transactionStore.transactions;
-  return [...list].sort((a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf());
+  return [...transactionStore.dailyTransactions].sort(
+    (a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf(),
+  );
 });
 
 const totalIncome = computed(() =>


### PR DESCRIPTION
  ## ✍🏻 PR 상세
  1. `isFiltered` computed 제거
     - `selectedDate`가 항상 날짜 문자열이므로 `isFiltered`는 항상 `true`였음
     - `filteredTransactions` fallback 브랜치는 실행되지 않는 dead code였음
  2. `displayedTransactions`를 `dailyTransactions`만 사용하도록 단순화
     - `isMonthView = true` → `dailyTransactions`가 월 전체 반환 (필터 적용)
     - `isMonthView = false` → `dailyTransactions`가 선택 날짜 반환 (필터 적용)

  ## 👀 참고사항
  - store의 `isMonthView` 및 `dailyTransactions` 변경(#64)에 대응한 작업입니다.
  - 변경 파일: `TransactionList.vue` 6줄 → 3줄

  ## ✅ 체크리스트
  - [x] 날짜 선택 시 해당 날짜의 거래 내역이 정상 표시된다.
  - [x] 월 전체 조회 시 이번 달 전체 거래 내역이 정상 표시된다.
  - [x] 유형/카테고리 필터가 날짜 선택 및 전체 조회 모두에서 유지된다.
  - [x] 기존 수정/삭제 동작에 영향이 없다.

  ## 🚪 연관된 이슈 번호
  Closes #63 