### PR TITLE
design: 거래 내역 조회 페이지 모바일 반응형 레이아웃 적용 및 UX 디테일 개선

### DIFF
--- a/src/components/calendar/CalendarGrid.vue
+++ b/src/components/calendar/CalendarGrid.vue
@@ -134,6 +134,9 @@ const selectDate = (dateString) => {
   transition: all 0.2s ease;
   display: flex;
   flex-direction: column;
+  transition: background-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .day-cell:nth-child(7n) {
@@ -183,5 +186,29 @@ const selectDate = (dateString) => {
 .record-expense {
   font-size: 14px;
   margin: 0;
+}
+
+/* 모바일 반응형 */
+@media (max-width: 768px) {
+  .weekday-cell {
+    padding: 10px 0;
+    font-size: 12px;
+  }
+
+  .day-cell {
+    padding: 4px;
+    min-height: 60px;
+  }
+
+  .date-num {
+    font-size: 12px;
+    width: 20px;
+    height: 20px;
+  }
+
+  .record-income,
+  .record-expense {
+    font-size: 10px;
+  }
 }
 </style>

--- a/src/components/calendar/FilterBar.vue
+++ b/src/components/calendar/FilterBar.vue
@@ -205,4 +205,56 @@ const handleTypeChange = () => {
 .month-all-btn:hover {
   opacity: 0.8;
 }
+
+/* 모바일 반응형 */
+@media (max-width: 768px) {
+  .filter-bar {
+    padding: 16px;
+    height: auto;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .month-nav {
+    order: 1;
+    width: 100%;
+    justify-content: center;
+    gap: 16px;
+  }
+
+  .current-month {
+    font-size: 16px;
+    width: 80px;
+  }
+
+  .icon-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .filter-group {
+    order: 2;
+    margin: 0;
+  }
+
+  .custom-select {
+    height: 36px;
+    padding: 0 24px 0 12px;
+    font-size: 12px;
+  }
+
+  .filter-icon-box {
+    width: 36px;
+    height: 36px;
+  }
+
+  .month-all-btn {
+    order: 3;
+    margin: 0;
+    height: 36px;
+    padding: 0 12px;
+    font-size: 12px;
+  }
+}
 </style>

--- a/src/components/calendar/TransactionList.vue
+++ b/src/components/calendar/TransactionList.vue
@@ -3,11 +3,11 @@
     <div class="summary-badges">
       <div class="badge badge-income">
         <span class="badge-label fw-medium">수입</span>
-        <span class="badge-amount fw-bold">+{{ totalIncome.toLocaleString("ko-KR") }}</span>
+        <span class="badge-amount fw-bold">+{{ totalIncome.toLocaleString('ko-KR') }}</span>
       </div>
       <div class="badge badge-expense">
         <span class="badge-label fw-medium">지출</span>
-        <span class="badge-amount fw-bold">-{{ totalExpense.toLocaleString("ko-KR") }}</span>
+        <span class="badge-amount fw-bold">-{{ totalExpense.toLocaleString('ko-KR') }}</span>
       </div>
     </div>
     <div class="list-header">
@@ -15,23 +15,19 @@
         <img :src="iconHistory" class="header-icon" alt="거래 상세" />
         <span class="header-title fw-medium text-black-2">거래 상세</span>
       </div>
-      <span class="header-count fw-regular text-black-2">총 {{ displayedTransactions.length }}건</span>
+      <span class="header-count fw-regular text-black-2"
+        >총 {{ displayedTransactions.length }}건</span
+      >
     </div>
 
-    <div v-if="transactionStore.loading" class="empty-msg text-black-2">
-      불러오는 중...
-    </div>
+    <div v-if="transactionStore.loading" class="empty-msg text-black-2">불러오는 중...</div>
 
     <div v-else-if="displayedTransactions.length === 0" class="empty-msg text-black-2">
       거래 내역이 없습니다.
     </div>
 
     <div v-else class="tx-list">
-      <div
-        v-for="tx in displayedTransactions"
-        :key="tx.id"
-        class="tx-item-wrapper"
-      >
+      <div v-for="tx in displayedTransactions" :key="tx.id" class="tx-item-wrapper">
         <div class="tx-item" @click="toggleSelected(tx.id)">
           <div class="tx-icon-wrap">
             <img
@@ -42,7 +38,7 @@
             />
           </div>
           <div class="tx-info">
-            <span class="tx-memo fw-semibold text-black-1">{{ tx.memo ?? "-" }}</span>
+            <span class="tx-memo fw-semibold text-black-1">{{ tx.memo ?? '-' }}</span>
             <span class="tx-date fw-regular text-black-2">{{ formatDate(tx.date) }}</span>
           </div>
           <span
@@ -55,29 +51,23 @@
 
         <div v-if="selectedId === tx.id && editingId !== tx.id" class="action-buttons">
           <button class="action-btn edit-btn fw-medium" @click.stop="startEdit(tx)">수정</button>
-          <button class="action-btn delete-btn fw-medium" @click.stop="deleteTransaction(tx.id)">삭제</button>
+          <button class="action-btn delete-btn fw-medium" @click.stop="deleteTransaction(tx.id)">
+            삭제
+          </button>
         </div>
 
         <div v-if="editingId === tx.id" class="edit-form">
           <div class="edit-row">
             <label class="edit-label fw-medium text-black-2">카테고리</label>
             <select v-model="editForm.categoryId" class="edit-select fw-regular">
-              <option
-                v-for="cat in filteredCategories(tx.type)"
-                :key="cat.id"
-                :value="cat.id"
-              >
+              <option v-for="cat in filteredCategories(tx.type)" :key="cat.id" :value="cat.id">
                 {{ cat.name }}
               </option>
             </select>
           </div>
           <div class="edit-row">
             <label class="edit-label fw-medium text-black-2">메모</label>
-            <input
-              v-model="editForm.memo"
-              class="edit-input fw-regular"
-              placeholder="메모"
-            />
+            <input v-model="editForm.memo" class="edit-input fw-regular" placeholder="메모" />
           </div>
           <div class="edit-row">
             <label class="edit-label fw-medium text-black-2">금액</label>
@@ -90,7 +80,9 @@
           </div>
           <div class="edit-actions">
             <button class="action-btn cancel-btn fw-medium" @click.stop="cancelEdit">취소</button>
-            <button class="action-btn save-btn fw-medium" @click.stop="submitEdit(tx.id)">저장</button>
+            <button class="action-btn save-btn fw-medium" @click.stop="submitEdit(tx.id)">
+              저장
+            </button>
           </div>
         </div>
       </div>
@@ -99,63 +91,59 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
-import { useTransactionStore } from "@/stores/useTransactionStore";
-import dayjs from "dayjs";
-import iconHistory from "@/assets/icons/category/category-history.png";
-import { getCategoryInfo, getCategoriesByType } from "@/constants/categories";
+import { ref, computed, onMounted } from 'vue'
+import { useTransactionStore } from '@/stores/useTransactionStore'
+import dayjs from 'dayjs'
+import iconHistory from '@/assets/icons/category/category-history.png'
+import { getCategoryInfo, getCategoriesByType } from '@/constants/categories'
 
 function filteredCategories(type) {
-  return getCategoriesByType(type);
+  return getCategoriesByType(type)
 }
 
 // TODO: useUserStore 연결 후 실제 userId로 교체
-const DUMMY_USER_ID = "u1";
+const DUMMY_USER_ID = 'u1'
 
-const transactionStore = useTransactionStore();
-const selectedId = ref(null);
-const editingId = ref(null);
-const editForm = ref({ memo: "", amount: 0, categoryId: "" });
+const transactionStore = useTransactionStore()
+const selectedId = ref(null)
+const editingId = ref(null)
+const editForm = ref({ memo: '', amount: 0, categoryId: '' })
 
 onMounted(async () => {
-  const now = dayjs();
-  await transactionStore.fetchMonthlyTransactions(
-    DUMMY_USER_ID,
-    now.year(),
-    now.month() + 1,
-  );
-});
+  const now = dayjs()
+  await transactionStore.fetchMonthlyTransactions(DUMMY_USER_ID, now.year(), now.month() + 1)
+})
 
 const displayedTransactions = computed(() => {
   return [...transactionStore.dailyTransactions].sort(
     (a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf(),
-  );
-});
+  )
+})
 
 const totalIncome = computed(() =>
   displayedTransactions.value
-    .filter((tx) => tx.type === "income")
+    .filter((tx) => tx.type === 'income')
     .reduce((sum, tx) => sum + tx.amount, 0),
-);
+)
 
 const totalExpense = computed(() =>
   displayedTransactions.value
-    .filter((tx) => tx.type === "expense")
+    .filter((tx) => tx.type === 'expense')
     .reduce((sum, tx) => sum + tx.amount, 0),
-);
+)
 
 function toggleSelected(id) {
-  editingId.value = null;
-  selectedId.value = selectedId.value === id ? null : id;
+  editingId.value = null
+  selectedId.value = selectedId.value === id ? null : id
 }
 
 function startEdit(tx) {
-  editingId.value = tx.id;
-  editForm.value = { memo: tx.memo ?? "", amount: tx.amount, categoryId: tx.categoryId };
+  editingId.value = tx.id
+  editForm.value = { memo: tx.memo ?? '', amount: tx.amount, categoryId: tx.categoryId }
 }
 
 function cancelEdit() {
-  editingId.value = null;
+  editingId.value = null
 }
 
 async function submitEdit(id) {
@@ -163,23 +151,23 @@ async function submitEdit(id) {
     memo: editForm.value.memo,
     amount: editForm.value.amount,
     categoryId: editForm.value.categoryId,
-  });
-  editingId.value = null;
-  selectedId.value = null;
+  })
+  editingId.value = null
+  selectedId.value = null
 }
 
 async function deleteTransaction(id) {
-  await transactionStore.deleteTransaction(id);
-  selectedId.value = null;
+  await transactionStore.deleteTransaction(id)
+  selectedId.value = null
 }
 
 function formatDate(date) {
-  return dayjs(date).format("YYYY. MM. DD");
+  return dayjs(date).format('YYYY. MM. DD')
 }
 
 function formatAmount(type, amount) {
-  const sign = type === "income" ? "+" : "-";
-  return `${sign}${amount.toLocaleString("ko-KR")}`;
+  const sign = type === 'income' ? '+' : '-'
+  return `${sign}${amount.toLocaleString('ko-KR')}`
 }
 </script>
 
@@ -384,5 +372,30 @@ function formatAmount(type, amount) {
   display: flex;
   gap: 8px;
   margin-top: 4px;
+}
+
+/* 모바일 반응형 */
+@media (max-width: 768px) {
+  .transaction-list {
+    padding: 16px 12px;
+    height: auto;
+    overflow-y: visible;
+  }
+
+  .tx-item {
+    padding: 10px 4px;
+  }
+
+  .tx-memo {
+    font-size: 14px;
+  }
+
+  .tx-amount {
+    font-size: 14px;
+  }
+
+  .badge-amount {
+    font-size: 14px;
+  }
 }
 </style>

--- a/src/pages/TransactionView.vue
+++ b/src/pages/TransactionView.vue
@@ -45,4 +45,19 @@ import TransactionList from '@/components/calendar/TransactionList.vue'
   flex: 1;
   font-size: 14px;
 }
+
+/* 모바일 반응형 */
+@media (max-width: 768px) {
+  .transaction-view {
+    flex-direction: column;
+    gap: 16px;
+    height: auto;
+  }
+
+  .left-panel,
+  .right-panel {
+    flex: none;
+    width: 100%;
+  }
+}
 </style>


### PR DESCRIPTION
## 📄 PR 요약
> `MainLayout`의 `isMobile` 브레이크포인트(768px)에 맞춰 **거래 내역 조회 페이지 전체의 모바일 반응형 레이아웃을 구현**했습니다.
> 추가로 달력 네비게이션 사용 시 브라우저 기본 포커스 아웃라인을 제거하였습니다.

## ✍🏻 PR 상세 내역

**1. 모바일 반응형 레이아웃 적용 (@media max-width: 768px)**
- `TransactionView`: 화면 축소 시 기존 좌우(3:2) 배치를 상하 배치(`flex-direction: column`)로 전환하여 모바일 가독성 확보.
- `FilterBar`: 모바일 환경의 한정된 세로 공간을 효율적으로 쓰기 위해 **2줄 역피라미드 레이아웃** 적용.
  - 1줄: 현재 날짜(월) 네비게이션을 정중앙에 단독 배치하여 인지성 강화
  - 2줄: 필터 그룹(좌)과 월 전체 조회 버튼(우)을 양 끝으로 배치.
- `CalendarGrid`: 좁은 화면에 맞춰 요일/날짜 셀 폰트 및 패딩 축소.
- `TransactionList`: 리스트 좌우 여백 축소 및 모바일 스크롤에 맞게 `overflow` 속성 최적화.

**2. UI/UX 디테일 개선 (Polish)**
- 달 이동 시 특정 날짜(1일 등) 셀에 브라우저 기본 포커스(검은색 테두리)가 노출되는 현상을 제거 (`outline: none !important`, `-webkit-tap-highlight-color`).

## ✅ 체크리스트
- [x] 브라우저 가로 폭을 768px 이하로 줄였을 때, 좌우 화면이 상하로 접힌다.
- [x] 모바일 화면에서 상단 필터바가 날짜(위), 필터+버튼(아래)의 2줄로 정렬된다.
- [x] 달력에서 이전 달/다음 달 화살표를 클릭해도 검은 줄이 생기지 않는다.
- [x] 달을 넘긴 직후, 특정 날짜가 아닌 해당 월의 '전체 조회' 상태가 잘 유지된다.

## 🚪 연관된 이슈 번호
Closes #33
Closes #66 
#45
