### PR TITLE
design: 월별 재정 요약 페이지 UI 개선 (#53)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.14.0",
-        "chart.js": "^4.5.1",
         "dayjs": "^1.11.20",
         "json-server": "^1.0.0-beta.15",
         "pinia": "^3.0.4",
-        "vue": "^3.5.31",
-        "vue3-emoji-picker": "^1.1.8",
-        "vue-chartjs": "^5.3.3",
-        "vue-router": "^5.0.4"
+        "vue-router": "^5.0.4",
+        "vue3-emoji-picker": "^1.1.8"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.5",
@@ -1585,18 +1582,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -2077,18 +2062,17 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/idb": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "license": "ISC"
-=======
     "node_modules/http-status-emojis": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http-status-emojis/-/http-status-emojis-2.2.0.tgz",
       "integrity": "sha512-ompKtgwpx8ff0hsbpIB7oE4ax1LXoHmftsHHStMELX56ivG3GhofTX8ZHWlUaFKfGjcGjw6G3rPk7dJRXMmbbg==",
       "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/inflection": {
       "version": "3.0.2",
@@ -2098,7 +2082,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
->>>>>>> develop
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -3372,16 +3355,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-chartjs": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
-      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,10 @@
   },
   "dependencies": {
     "axios": "^1.14.0",
-    "chart.js": "^4.5.1",
     "dayjs": "^1.11.20",
     "json-server": "^1.0.0-beta.15",
     "pinia": "^3.0.4",
     "vue3-emoji-picker": "^1.1.8",
-    "vue-chartjs": "^5.3.3",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {

--- a/src/components/summary/CategoryDonutChart.vue
+++ b/src/components/summary/CategoryDonutChart.vue
@@ -29,6 +29,7 @@ const activeItem = computed(
     null,
 )
 
+// 현재 선택된 카테고리가 전체 지출에서 차지하는 비율
 const activeShare = computed(() => {
   if (!activeItem.value || totalAmount.value === 0) return 0
   return Math.round((activeItem.value.amount / totalAmount.value) * 100)
@@ -42,6 +43,7 @@ const polarToCartesian = (cx, cy, radius, angle) => {
   }
 }
 
+// 시작/끝 각도를 바탕으로 도넛 조각 SVG path 만들기
 const createArcPath = (startAngle, endAngle, outerRadius, innerRadius) => {
   const outerStart = polarToCartesian(120, 120, outerRadius, startAngle)
   const outerEnd = polarToCartesian(120, 120, outerRadius, endAngle)
@@ -58,6 +60,7 @@ const createArcPath = (startAngle, endAngle, outerRadius, innerRadius) => {
   ].join(' ')
 }
 
+// 카테고리 비율을 도넛 segment 데이터로 바꾸기
 const chartSegments = computed(() => {
   if (!props.items.length || totalAmount.value === 0) return []
 

--- a/src/components/summary/CategoryDonutChart.vue
+++ b/src/components/summary/CategoryDonutChart.vue
@@ -23,7 +23,10 @@ const totalAmount = computed(() =>
 )
 
 const activeItem = computed(
-  () => props.items.find((item) => item.categoryId === props.activeCategoryId) ?? props.items[0] ?? null,
+  () =>
+    props.items.find((item) => item.categoryId === props.activeCategoryId) ??
+    props.items[0] ??
+    null,
 )
 
 const activeShare = computed(() => {
@@ -84,10 +87,13 @@ const formatMonthLabel = computed(() => {
 })
 
 const emitHoverCategory = (categoryId, event) => {
+  const targetRect = event.currentTarget?.getBoundingClientRect?.()
+
+  // 포인터 좌표가 없으면 현재 segment의 중심 좌표를 툴팁 기준점으로 사용
   emit('hover-category', {
     categoryId,
-    clientX: event.clientX,
-    clientY: event.clientY,
+    clientX: event.clientX ?? targetRect?.left + targetRect?.width / 2 ?? 0,
+    clientY: event.clientY ?? targetRect?.top + targetRect?.height / 2 ?? 0,
     source: 'chart',
   })
 }
@@ -98,7 +104,7 @@ const emitHoverCategory = (categoryId, event) => {
     <div class="donut-card__header">
       <div>
         <h2 class="donut-card__title">어디에 많이 썼을까?</h2>
-        <p class="donut-card__description">가장 큰 지출 항목을 마우스로 살펴보세요.</p>
+        <p class="donut-card__description">각 항목에 마우스를 올려보세요!</p>
       </div>
     </div>
 
@@ -119,6 +125,7 @@ const emitHoverCategory = (categoryId, event) => {
             :class="{ 'category-donut-chart__segment--active': segment.active }"
             @mouseenter="emitHoverCategory(segment.categoryId, $event)"
             @mousemove="emitHoverCategory(segment.categoryId, $event)"
+            @click="emitHoverCategory(segment.categoryId, $event)"
           />
         </svg>
 
@@ -155,35 +162,36 @@ const emitHoverCategory = (categoryId, event) => {
   background: #ffffff;
   border: 1px solid rgba(23, 25, 28, 0.06);
   border-radius: 24px;
-  padding: 18px;
+  min-height: 328px;
+  padding: 22px 22px 18px;
   box-shadow: 0 14px 28px rgba(23, 25, 28, 0.06);
 }
 
 .donut-card__title {
   margin: 0;
   color: var(--black-1);
-  font-size: 21px;
+  font-size: 24px;
   font-weight: 800;
 }
 
 .donut-card__description {
   margin-top: 6px;
   color: var(--black-2);
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .donut-card__body {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
-  gap: 20px;
+  grid-template-columns: 256px minmax(0, 1fr);
+  gap: 18px;
   align-items: center;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .category-donut-chart {
   position: relative;
-  width: 240px;
-  height: 240px;
+  width: 256px;
+  height: 248px;
   margin: 0 auto;
 }
 
@@ -210,7 +218,7 @@ const emitHoverCategory = (categoryId, event) => {
 
 .category-donut-chart__center {
   position: absolute;
-  inset: 62px;
+  inset: 64px;
   border-radius: 50%;
   background: #ffffff;
   display: flex;
@@ -224,20 +232,20 @@ const emitHoverCategory = (categoryId, event) => {
 
 .category-donut-chart__month {
   color: var(--black-2);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
 }
 
 .category-donut-chart__share {
   margin-top: 8px;
   color: var(--black-1);
-  font-size: 34px;
+  font-size: 36px;
   font-weight: 900;
   line-height: 1;
 }
 
 .category-donut-chart--empty {
-  min-height: 240px;
+  min-height: 280px;
   color: var(--black-2);
   font-size: 14px;
   display: flex;
@@ -248,7 +256,7 @@ const emitHoverCategory = (categoryId, event) => {
 .donut-card__legend {
   list-style: none;
   display: grid;
-  gap: 12px;
+  gap: 16px;
   padding: 0;
   margin: 0;
 }
@@ -256,8 +264,8 @@ const emitHoverCategory = (categoryId, event) => {
 .donut-card__legend-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  min-height: 28px;
+  gap: 12px;
+  min-height: 34px;
   padding: 0;
   border-radius: 0;
   background: transparent;
@@ -269,25 +277,36 @@ const emitHoverCategory = (categoryId, event) => {
 }
 
 .donut-card__swatch {
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
 .donut-card__legend-label {
   color: var(--black-2);
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 700;
 }
 
 @media (max-width: 640px) {
   .donut-card {
-    padding: 18px 16px;
+    min-height: auto;
+    padding: 20px 18px 18px;
   }
 
   .donut-card__body {
     grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .category-donut-chart {
+    width: 248px;
+    height: 248px;
+  }
+
+  .category-donut-chart__center {
+    inset: 64px;
   }
 }
 </style>

--- a/src/components/summary/ComparisonTooltip.vue
+++ b/src/components/summary/ComparisonTooltip.vue
@@ -1,5 +1,7 @@
 ﻿<script setup>
 import { computed } from 'vue'
+
+// 부모가 전달한 comparison 데이터와 좌표로 소비 비교 툴팁 표시
 const props = defineProps({
   comparison: {
     type: Object,

--- a/src/components/summary/ComparisonTooltip.vue
+++ b/src/components/summary/ComparisonTooltip.vue
@@ -41,15 +41,15 @@ const summary = computed(() => {
 .comparison-tooltip {
   position: absolute;
   z-index: 20;
-  width: 212px;
+  width: 236px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  min-height: 44px;
-  padding: 8px 10px;
+  gap: 10px;
+  min-height: 52px;
+  padding: 10px 12px;
   background: linear-gradient(135deg, #ffffff 0%, #f7f7fa 100%);
   border: 1px solid rgba(23, 25, 28, 0.06);
-  border-radius: 18px;
+  border-radius: 20px;
   box-shadow: 0 10px 18px rgba(23, 25, 28, 0.05);
   opacity: 0;
   visibility: hidden;
@@ -68,16 +68,16 @@ const summary = computed(() => {
 }
 
 .comparison-tooltip__icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 12px;
   background: #fffdf4;
   border: 1px solid rgba(23, 25, 28, 0.06);
   display: flex;
   align-items: center;
   justify-content: center;
   color: #f4b52d;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 800;
   flex-shrink: 0;
 }
@@ -98,7 +98,7 @@ const summary = computed(() => {
 .comparison-tooltip__title {
   -webkit-line-clamp: 1;
   color: var(--black-1);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 800;
 }
 
@@ -106,7 +106,7 @@ const summary = computed(() => {
   -webkit-line-clamp: 2;
   margin-top: 4px;
   color: var(--black-2);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
 }
 </style>

--- a/src/components/summary/TrendBarChart.vue
+++ b/src/components/summary/TrendBarChart.vue
@@ -23,51 +23,65 @@ const seriesMeta = [
   { key: 'income', label: '수입', color: 'var(--orange-1)' },
   { key: 'expense', label: '지출', color: 'var(--black-2)' },
   { key: 'net', label: '순이익', color: 'var(--green-1)' },
+  { key: 'loss', label: '적자', color: 'var(--yellow-1)' },
 ]
 
-const visibleSeries = computed(() =>
-  props.selectedMetric === 'all'
-    ? seriesMeta
-    : seriesMeta.filter((series) => series.key === props.selectedMetric),
-)
+// 순이익이 음수인 달이 있으면 전체/순이익 탭에서 적자 범주를 노출
+const visibleSeries = computed(() => {
+  const hasLoss = props.monthlyData.some((item) => (item.net ?? 0) < 0)
+  const hasPositiveNet = props.monthlyData.some((item) => (item.net ?? 0) >= 0)
+
+  if (props.selectedMetric === 'all') {
+    return seriesMeta.filter((series) => {
+      if (series.key === 'net') return hasPositiveNet
+      if (series.key === 'loss') return hasLoss
+      return ['income', 'expense'].includes(series.key)
+    })
+  }
+
+  if (props.selectedMetric === 'net') {
+    return seriesMeta.filter((series) => {
+      if (series.key === 'net') return hasPositiveNet
+      if (series.key === 'loss') return hasLoss
+      return false
+    })
+  }
+
+  return seriesMeta.filter((series) => series.key === props.selectedMetric)
+})
+
+// 적자는 음수 순이익을 절댓값으로 변환해 별도 막대로 표현
+const getSeriesValue = (item, seriesKey) => {
+  if (seriesKey === 'loss') {
+    return (item.net ?? 0) < 0 ? Math.abs(item.net ?? 0) : null
+  }
+
+  if (seriesKey === 'net') {
+    return (item.net ?? 0) >= 0 ? (item.net ?? 0) : null
+  }
+
+  return item[seriesKey] ?? 0
+}
+
+const getRenderedSeries = (item) =>
+  visibleSeries.value.filter((series) => getSeriesValue(item, series.key) !== null)
 
 const maxAbsValue = computed(() => {
   const values = props.monthlyData.flatMap((item) =>
-    visibleSeries.value.map((series) => item[series.key] ?? 0),
+    getRenderedSeries(item).map((series) => getSeriesValue(item, series.key) ?? 0),
   )
   return Math.max(...values.map((value) => Math.abs(value)), 1)
 })
 
-const baselineRatio = computed(() => {
-  const hasNegative = props.monthlyData.some((item) =>
-    visibleSeries.value.some((series) => (item[series.key] ?? 0) < 0),
-  )
-  return hasNegative ? 50 : 100
-})
-
+// 값의 크기를 최대값 대비 비율로 계산
 const getBarStyle = (value, color) => {
-  const ratio = (Math.abs(value) / maxAbsValue.value) * baselineRatio.value
+  const ratio = (Math.abs(value) / maxAbsValue.value) * 100
 
-  if (baselineRatio.value === 100) {
-    return {
-      height: `${Math.max(ratio, 6)}%`,
-      background: color,
-      alignSelf: 'end',
-    }
+  return {
+    height: `${Math.max(ratio, 6)}%`,
+    background: color,
+    alignSelf: 'end',
   }
-
-  return value >= 0
-    ? {
-        height: `${Math.max(ratio, 6)}%`,
-        background: color,
-        alignSelf: 'end',
-      }
-    : {
-        height: `${Math.max(ratio, 6)}%`,
-        background: color,
-        opacity: 0.82,
-        alignSelf: 'start',
-      }
 }
 
 const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}원`
@@ -92,20 +106,21 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
     </div>
 
     <div v-if="monthlyData.length" class="trend-chart">
-      <div v-if="baselineRatio === 50" class="trend-chart__baseline" />
-
       <div v-for="item in monthlyData" :key="item.monthKey" class="trend-chart__group">
         <div
           class="trend-chart__bars"
-          :class="{ 'trend-chart__bars--single': visibleSeries.length === 1 }"
+          :class="{ 'trend-chart__bars--single': getRenderedSeries(item).length === 1 }"
         >
           <div
-            v-for="series in visibleSeries"
+            v-for="series in getRenderedSeries(item)"
             :key="series.key"
             class="trend-chart__bar-wrap"
-            :title="`${item.label} ${series.label} ${formatCurrency(item[series.key])}`"
+            :data-tooltip="`${item.label} ${series.label} ${formatCurrency(getSeriesValue(item, series.key))}`"
           >
-            <div class="trend-chart__bar" :style="getBarStyle(item[series.key], series.color)" />
+            <div
+              class="trend-chart__bar"
+              :style="getBarStyle(getSeriesValue(item, series.key), series.color)"
+            />
           </div>
         </div>
         <div class="trend-chart__label">{{ item.label }}</div>
@@ -174,16 +189,8 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: 16px;
   min-height: 254px;
-}
-
-.trend-chart__baseline {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  border-top: 1px dashed rgba(23, 25, 28, 0.12);
 }
 
 .trend-chart__group {
@@ -194,10 +201,9 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 
 .trend-chart__bars {
   min-height: 214px;
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(0, 1fr);
-  gap: 8px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
   align-items: stretch;
   padding: 14px 20px 0;
   border-radius: 24px;
@@ -217,6 +223,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   justify-content: flex-end;
   min-height: 100%;
   align-items: center;
+  position: relative;
 }
 
 .trend-chart__bar {
@@ -227,6 +234,59 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   box-shadow: 0 8px 14px rgba(23, 25, 28, 0.08);
   animation: trend-bar-grow 0.65s ease both;
   transform-origin: bottom;
+}
+
+.trend-chart__bar-wrap::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%) translateY(3px);
+  min-width: max-content;
+  max-width: 168px;
+  padding: 7px 10px;
+  border-radius: 12px;
+  background: rgba(23, 25, 28, 0.92);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+  text-align: center;
+  white-space: nowrap;
+  box-shadow: 0 10px 18px rgba(23, 25, 28, 0.16);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+  z-index: 2;
+}
+
+.trend-chart__bar-wrap::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 2px);
+  width: 10px;
+  height: 10px;
+  background: rgba(23, 25, 28, 0.92);
+  transform: translateX(-50%) rotate(45deg) translateY(3px);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+  z-index: 1;
+}
+
+.trend-chart__bar-wrap:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.trend-chart__bar-wrap:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) rotate(45deg) translateY(0);
 }
 
 .trend-chart__group:nth-child(1) .trend-chart__bar {

--- a/src/components/summary/TrendBarChart.vue
+++ b/src/components/summary/TrendBarChart.vue
@@ -13,10 +13,10 @@ const props = defineProps({
 })
 
 const descriptionMap = {
-  all: '최근 3개월의 수입, 지출, 순이익 흐름을 한 번에 볼 수 있어요.',
-  income: '최근 3개월 수입 흐름만 집중해서 볼 수 있어요.',
-  expense: '최근 3개월 지출 흐름만 집중해서 볼 수 있어요.',
-  net: '최근 3개월 순이익 변화를 확인할 수 있어요.',
+  all: '최근 3개월의 수입, 지출, 순이익 흐름을 볼 수 있어요.',
+  income: '최근 3개월 수입 흐름을 볼 수 있어요.',
+  expense: '최근 3개월 지출 흐름을 볼 수 있어요.',
+  net: '최근 3개월 순이익 변화를 볼 수 있어요.',
 }
 
 const seriesMeta = [
@@ -123,49 +123,50 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   background: #ffffff;
   border: 1px solid rgba(23, 25, 28, 0.05);
   border-radius: 24px;
-  padding: 18px 20px 14px;
+  min-height: 328px;
+  padding: 22px 22px 18px;
   box-shadow: 0 10px 24px rgba(23, 25, 28, 0.05);
 }
 
 .trend-card__header {
   display: flex;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 10px;
+  gap: 18px;
+  margin-bottom: 14px;
 }
 
 .trend-card__title {
   margin: 0;
   color: var(--black-1);
-  font-size: 18px;
+  font-size: 24px;
   font-weight: 800;
 }
 
 .trend-card__description {
-  margin-top: 4px;
+  margin-top: 6px;
   color: var(--black-2);
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .trend-card__legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 14px;
+  gap: 12px 16px;
   align-self: flex-start;
 }
 
 .trend-card__legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   color: var(--black-2);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 700;
 }
 
 .trend-card__legend-dot {
-  width: 10px;
-  height: 10px;
+  width: 11px;
+  height: 11px;
   border-radius: 50%;
 }
 
@@ -174,7 +175,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
-  min-height: 246px;
+  min-height: 254px;
 }
 
 .trend-chart__baseline {
@@ -187,7 +188,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 
 .trend-chart__group {
   display: grid;
-  gap: 8px;
+  gap: 10px;
   align-items: end;
 }
 
@@ -196,10 +197,10 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: minmax(0, 1fr);
-  gap: 6px;
+  gap: 8px;
   align-items: stretch;
-  padding: 12px 24px 0;
-  border-radius: 20px;
+  padding: 14px 20px 0;
+  border-radius: 24px;
   background:
     linear-gradient(to top, rgba(23, 25, 28, 0.04) 1px, transparent 1px) 0 100% / 100% 25%,
     #fafafb;
@@ -219,17 +220,31 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 }
 
 .trend-chart__bar {
-  width: 22px;
+  width: 30px;
   max-width: 100%;
   border-radius: 10px 10px 4px 4px;
   min-height: 6px;
   box-shadow: 0 8px 14px rgba(23, 25, 28, 0.08);
+  animation: trend-bar-grow 0.65s ease both;
+  transform-origin: bottom;
+}
+
+.trend-chart__group:nth-child(1) .trend-chart__bar {
+  animation-delay: 0.08s;
+}
+
+.trend-chart__group:nth-child(2) .trend-chart__bar {
+  animation-delay: 0.16s;
+}
+
+.trend-chart__group:nth-child(3) .trend-chart__bar {
+  animation-delay: 0.24s;
 }
 
 .trend-chart__label {
   text-align: center;
   color: var(--black-2);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 700;
 }
 
@@ -237,14 +252,28 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 220px;
+  min-height: 240px;
   color: var(--black-2);
   font-size: 14px;
 }
 
+/* 막대 차트 애니메이션  */
+@keyframes trend-bar-grow {
+  from {
+    opacity: 0.35;
+    transform: scaleY(0.12);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
 @media (max-width: 640px) {
   .trend-card {
-    padding: 14px 16px 10px;
+    min-height: auto;
+    padding: 18px 18px 14px;
   }
 
   .trend-card__header {
@@ -253,6 +282,16 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 
   .trend-chart {
     gap: 10px;
+    min-height: 230px;
+  }
+
+  .trend-chart__bars {
+    min-height: 188px;
+    padding: 14px 16px 0;
+  }
+
+  .trend-chart__bar {
+    width: 24px;
   }
 }
 </style>

--- a/src/pages/SummaryView.vue
+++ b/src/pages/SummaryView.vue
@@ -53,6 +53,8 @@ const shiftMonthKey = (monthKey, diff) => {
 const currentUserId = computed(() => window.localStorage.getItem('userId') || FALLBACK_USER_ID)
 const loading = computed(() => transactionStore.rangeLoading)
 const transactions = computed(() => transactionStore.rangeTransactions)
+
+// 조회한 기간 데이터 중 가장 최신 월을 기본 선택 월로 사용
 const latestRangeMonthKey = computed(() => {
   if (!transactions.value.length) return dayjs().format('YYYY-MM')
 
@@ -77,6 +79,7 @@ const getCategoryExpense = (monthKey, categoryId) =>
     )
     .reduce((sum, tx) => sum + Number(tx.amount || 0), 0)
 
+// 선택된 월을 기준으로 최근 3개월의 수입/지출/순이익 통계
 const recentThreeMonthStats = computed(() => {
   if (!selectedMonthKey.value) return []
 
@@ -102,6 +105,7 @@ const monthlySummaryCards = computed(() =>
   })),
 )
 
+// 현재 선택 월의 지출 카테고리별 금액과 지난달 비교값을 함께 계산
 const selectedMonthExpenseCategories = computed(() => {
   if (!selectedMonthKey.value) return []
 
@@ -220,6 +224,7 @@ const handleLeaveHighlightCategory = () => {
   tooltipCategoryId.value = null
 }
 
+// 최근 3개월 거래와 카테고리 목록을 함께 불러와 summary 화면의 기준 데이터를 준비
 const fetchSummaryData = async () => {
   const end = dayjs().endOf('month').format('YYYY-MM-DD')
   const start = dayjs(end).subtract(2, 'month').startOf('month').format('YYYY-MM-DD')
@@ -243,9 +248,6 @@ const fetchSummaryData = async () => {
 }
 
 onMounted(() => {
-  selectedMetric.value = 'all'
-  highlightedCategoryId.value = null
-  tooltipPosition.value = { x: 0, y: 0 }
   fetchSummaryData()
 })
 </script>

--- a/src/pages/SummaryView.vue
+++ b/src/pages/SummaryView.vue
@@ -17,10 +17,10 @@ const TOOLTIP_HEIGHT = 60
 const TOOLTIP_OFFSET = 16
 
 const CATEGORY_STYLES = {
-  c3: { color: '#FBD4AC', icon: FoodIcon, iconLabel: '식비' },
-  c4: { color: '#AFC7F6', icon: TransportIcon, iconLabel: '교통' },
-  c5: { color: '#D8C0E8', icon: ShopIcon, iconLabel: '쇼핑' },
-  c6: { color: '#91DED1', icon: CultureIcon, iconLabel: '문화' },
+  c3: { color: 'var(--yellow-1)', icon: FoodIcon, iconLabel: '식비' },
+  c4: { color: 'var(--blue-1)', icon: TransportIcon, iconLabel: '교통' },
+  c5: { color: 'var(--purple-1)', icon: ShopIcon, iconLabel: '쇼핑' },
+  c6: { color: 'var(--green-1)', icon: CultureIcon, iconLabel: '문화' },
 }
 
 const metricTypes = [
@@ -193,9 +193,26 @@ const handleLeaveCategory = () => {
   tooltipCategoryId.value = null
 }
 
-const handleHighlightCategory = (categoryId) => {
+// 카테고리 hover나 click 시 툴팁 대상과 위치 함께 갱신
+const handleHighlightCategory = (categoryId, event) => {
   highlightedCategoryId.value = categoryId
   tooltipCategoryId.value = categoryId
+  if (event?.currentTarget) {
+    updateTooltipPositionFromElement(event.currentTarget)
+  } else if (event) {
+    updateTooltipPosition(event.clientX, event.clientY)
+  }
+}
+
+// 리스트 hover에서는 포인터 대신 요소를 기준으로 위치 설정
+const updateTooltipPositionFromElement = (element) => {
+  const targetRect = element?.getBoundingClientRect?.()
+  if (!targetRect) return
+
+  updateTooltipPosition(
+    targetRect.left + targetRect.width / 2,
+    targetRect.top + targetRect.height / 2,
+  )
 }
 
 const handleLeaveHighlightCategory = () => {
@@ -254,7 +271,11 @@ onMounted(() => {
 
     <div class="summary-content">
       <section class="summary-content__left">
-        <TrendBarChart :monthly-data="recentThreeMonthStats" :selected-metric="selectedMetric" />
+        <TrendBarChart
+          :key="`trend-${selectedMetric}`"
+          :monthly-data="recentThreeMonthStats"
+          :selected-metric="selectedMetric"
+        />
 
         <div class="monthly-summary-list">
           <article
@@ -266,13 +287,13 @@ onMounted(() => {
             <div class="monthly-summary-card__month">{{ item.label.replace('월', '') }}월</div>
             <p class="monthly-summary-card__title">월간 요약</p>
             <div class="monthly-summary-card__metric">
-              <span class="monthly-summary-card__label">INCOME</span>
+              <span class="monthly-summary-card__label">수입</span>
               <strong class="monthly-summary-card__income"
                 >+{{ formatCurrency(item.income) }}</strong
               >
             </div>
             <div class="monthly-summary-card__metric">
-              <span class="monthly-summary-card__label">EXPENSE</span>
+              <span class="monthly-summary-card__label">지출</span>
               <strong class="monthly-summary-card__expense"
                 >-{{ formatCurrency(item.expense) }}</strong
               >
@@ -283,6 +304,7 @@ onMounted(() => {
 
       <section class="summary-content__right">
         <CategoryDonutChart
+          :key="`donut-${selectedMetric}`"
           :items="selectedMonthExpenseCategories"
           :active-category-id="highlightedCategoryId"
           :month-label="selectedMonthKey"
@@ -296,7 +318,9 @@ onMounted(() => {
             :key="item.categoryId"
             class="category-row"
             :class="{ 'category-row--active': highlightedCategoryId === item.categoryId }"
-            @mouseenter="handleHighlightCategory(item.categoryId)"
+            @mouseenter="handleHighlightCategory(item.categoryId, $event)"
+            @mousemove="handleHighlightCategory(item.categoryId, $event)"
+            @click="handleHighlightCategory(item.categoryId, $event)"
             @mouseleave="handleLeaveHighlightCategory"
           >
             <div class="category-row__left">
@@ -328,10 +352,10 @@ onMounted(() => {
 
 .summary-view {
   position: relative;
-  height: 100%;
+  height: auto;
   overflow: visible;
   display: grid;
-  gap: 10px;
+  gap: 12px;
   padding-right: 4px;
   padding-bottom: 8px;
 }
@@ -340,31 +364,31 @@ onMounted(() => {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  min-height: 64px;
-  padding-top: 2px;
+  gap: 14px;
+  min-height: 0;
 }
 
 .summary-content {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  grid-template-columns: minmax(0, 1.28fr) minmax(372px, 0.92fr);
   gap: 18px;
+  align-items: start;
 }
 
 .summary-content__left,
 .summary-content__right {
   display: grid;
-  gap: 10px;
+  gap: 14px;
   align-content: start;
 }
 
 .metric-toggle {
   display: inline-flex;
-  gap: 4px;
+  gap: 6px;
   width: fit-content;
-  padding: 4px;
+  padding: 6px;
   background: #ffffff;
-  border-radius: 18px;
+  border-radius: 20px;
   border: 1px solid rgba(23, 25, 28, 0.08);
   box-shadow: 0 8px 18px rgba(23, 25, 28, 0.05);
 }
@@ -373,9 +397,9 @@ onMounted(() => {
   border: none;
   background: transparent;
   color: var(--black-2);
-  border-radius: 14px;
-  padding: 10px 16px;
-  font-size: 13px;
+  border-radius: 16px;
+  padding: 12px 20px;
+  font-size: 15px;
   font-weight: 700;
   cursor: pointer;
 }
@@ -387,7 +411,7 @@ onMounted(() => {
 
 .monthly-summary-list {
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
 .monthly-summary-card,
@@ -400,10 +424,10 @@ onMounted(() => {
 
 .monthly-summary-card {
   display: grid;
-  grid-template-columns: 58px minmax(0, 1fr) 140px 140px;
+  grid-template-columns: 64px minmax(0, 1fr) 160px 160px;
   align-items: center;
-  gap: 10px;
-  padding: 12px 17px;
+  gap: 14px;
+  padding: 18px 22px;
 }
 
 .monthly-summary-card--latest {
@@ -413,21 +437,21 @@ onMounted(() => {
 }
 
 .monthly-summary-card__month {
-  width: 40px;
-  height: 40px;
+  width: 46px;
+  height: 46px;
   border-radius: 50%;
   background: var(--black-3);
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--black-1);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 800;
 }
 
 .monthly-summary-card__title {
   color: var(--black-1);
-  font-size: 15px;
+  font-size: 18px;
   font-weight: 800;
 }
 
@@ -437,21 +461,20 @@ onMounted(() => {
 
 .monthly-summary-card__label {
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
   color: #8e96a3;
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 800;
-  letter-spacing: 0.08em;
 }
 
 .monthly-summary-card__income,
 .monthly-summary-card__expense {
-  font-size: 14px;
+  font-size: 18px;
   font-weight: 800;
 }
 
 .monthly-summary-card__income {
-  color: var(--black-1);
+  color: var(--green-1);
 }
 
 .monthly-summary-card__expense {
@@ -459,15 +482,15 @@ onMounted(() => {
 }
 
 .category-list-card {
-  padding: 10px;
+  padding: 12px;
 }
 
 .category-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 13px 12px;
+  gap: 14px;
+  padding: 15px 14px;
   border-radius: 18px;
   background: #ffffff;
   transition:
@@ -487,13 +510,13 @@ onMounted(() => {
 .category-row__left {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .category-row__icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 15px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -509,19 +532,19 @@ onMounted(() => {
 
 .category-row__icon span {
   color: #ffffff;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 800;
 }
 
 .category-row__name {
   color: var(--black-1);
-  font-size: 14px;
-  font-weight: 800;
+  font-size: 19px;
+  font-weight: 700;
 }
 
 .category-row__amount {
   color: var(--black-1);
-  font-size: 14px;
+  font-size: 19px;
   font-weight: 800;
 }
 
@@ -544,11 +567,16 @@ onMounted(() => {
   }
 
   .summary-view {
-    gap: 16px;
+    gap: 12px;
   }
 
   .monthly-summary-card {
     grid-template-columns: 58px 1fr;
+    padding: 16px 18px;
+  }
+
+  .category-row {
+    padding: 13px 12px;
   }
 }
 </style>


### PR DESCRIPTION
## 📄 PR 요약
> 월별 재정 요약 페이지의 차트 UI를 다듬고, 순이익 표시 방식과 툴팁 동작을 개선했습니다.

## ✍🏻 PR 상세
1. SummaryView와 summary 차트 컴포넌트의 레이아웃, 간격, 카드 크기, 리스트 스타일을 조정해 요약 화면 UI를 정리했습니다.
2. TrendBarChart에서 막대 차트 애니메이션과 툴팁 스타일을 개선하고, 순이익이 음수인 경우 적자 범주로 분리해 절댓값 기준 막대로 표시하도록 수정했습니다.
3. CategoryDonutChart와 ComparisonTooltip의 표시 크기와 인터랙션을 보완했습니다.
4. summary 관련 주요 계산/인터랙션 로직에 주석을 추가했습니다.
5. 사용하지 않는 차트 의존성을 정리하면서 package.json, package-lock.json도 함께 정리했습니다.

## 👀 참고사항
- 반응형 및 authStore 연동은 추후 수정할 예정입니다.
- 커밋 메시지가 깔끔하지 않은 부분이 있습니다. 기능 변경과는 무관합니다....

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #53 