### PR TITLE
design: 프로필 페이지 반응형 디자인

### DIFF
--- a/src/components/common/sidebar/ProfileCard.vue
+++ b/src/components/common/sidebar/ProfileCard.vue
@@ -7,7 +7,7 @@
     </p>
   </div>
   <div class="profile-card bg-yellow-2 border-yellow-1 justify-align" v-else>
-    <p class="text-black-1 fw-black">로그인 후 이용 가능합니다</p>
+    <p class="not-logged text-black-1 fw-black">로그인 후 이용 가능합니다</p>
   </div>
 </template>
 
@@ -83,6 +83,12 @@ p {
   .hello {
     font-size: 14px;
     align-self: start;
+  }
+
+  .not-logged {
+    grid-row: 1 / 3;
+    grid-column: 1 / 3;
+    justify-self: center;
   }
 }
 </style>

--- a/src/components/profile/AuthBox.vue
+++ b/src/components/profile/AuthBox.vue
@@ -19,4 +19,11 @@ import AuthButton from './AuthButton.vue'
   justify-self: end;
   align-items: end;
 }
+
+@media (max-width: 768px) {
+  .auth-box {
+    gap: 8px;
+    justify-content: center;
+  }
+}
 </style>

--- a/src/components/profile/GoalInput.vue
+++ b/src/components/profile/GoalInput.vue
@@ -48,4 +48,17 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+@media (max-width: 768px) {
+  .goal-input {
+    width: 100%;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  input {
+    width: 100%;
+    font-size: 16px;
+  }
+}
 </style>

--- a/src/components/profile/GoalItem.vue
+++ b/src/components/profile/GoalItem.vue
@@ -48,9 +48,10 @@ const userStore = useUserStore()
 
 .goal-content {
   width: 100%;
-  height: 88px;
+  height: fit-content;
+  min-height: 88px;
   border-radius: 32px;
-  padding-left: 32px;
+  padding: 20px 32px;
   box-sizing: border-box;
   display: flex;
   align-items: center;

--- a/src/components/profile/GoalModify.vue
+++ b/src/components/profile/GoalModify.vue
@@ -25,4 +25,10 @@ const userStore = useUserStore()
   display: flex;
   gap: 36px;
 }
+
+@media (max-width: 768px) {
+  .goal-modify {
+    flex-direction: column;
+  }
+}
 </style>

--- a/src/components/profile/InfoBox.vue
+++ b/src/components/profile/InfoBox.vue
@@ -24,4 +24,10 @@ import InfoItem from './InfoItem.vue'
 
   margin-top: 48px;
 }
+
+@media (max-width: 768px) {
+  .info-box {
+    margin: 24px 0;
+  }
+}
 </style>

--- a/src/components/profile/ModifyBox.vue
+++ b/src/components/profile/ModifyBox.vue
@@ -23,4 +23,10 @@ const userStore = useUserStore()
   display: flex;
   gap: 14px;
 }
+
+@media (max-width: 768px) {
+  .button-box {
+    align-self: end;
+  }
+}
 </style>

--- a/src/components/profile/ModifyImoji.vue
+++ b/src/components/profile/ModifyImoji.vue
@@ -22,4 +22,13 @@ div {
   top: 128px;
   left: 128px;
 }
+
+@media (max-width: 768px) {
+  div {
+    width: 32px;
+    height: 32px;
+    top: 68px;
+    left: 68px;
+  }
+}
 </style>

--- a/src/components/profile/ProfileBox.vue
+++ b/src/components/profile/ProfileBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="box-default profile-box">
-    <ProfileImoji />
     <ModifyBox />
+    <ProfileImoji />
     <InfoBox />
     <AuthBox v-if="!userStore.isModifying" />
   </div>
@@ -29,5 +29,15 @@ const userStore = useUserStore()
   display: grid;
   grid-template-columns: 180px 1fr;
   grid-template-rows: 180px auto 98px;
+}
+
+@media (max-width: 768px) {
+  .profile-box {
+    display: flex;
+    flex-direction: column;
+
+    padding: 32px;
+    gap: 18px;
+  }
 }
 </style>

--- a/src/components/profile/ProfileImoji.vue
+++ b/src/components/profile/ProfileImoji.vue
@@ -58,4 +58,17 @@ const onSelectEmoji = (emoji) => {
   font-size: 14px !important;
   line-height: 1.2;
 }
+
+@media (max-width: 768px) {
+  .imoji-box {
+    width: 100px;
+    height: 100px;
+
+    font-size: 60px;
+  }
+
+  .picker-wrapper {
+    top: 112px;
+  }
+}
 </style>


### PR DESCRIPTION
## 📄 PR 요약
> 프로필 페이지 반응형 추가했습니다

## ✍🏻 PR 상세
1. 기존 grid 템플릿을 flex (direction: column)으로 변경
2. 프로필 사진 크기 줄임
3. 목표 텍스트 길어질 시 박스 크기 대응되도록!

## 👀 참고사항
- 로그인 안 했을 때 탑바 사이드카드도 오류 있길래 수정해 뒀어염

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #45
