### PR TITLE
design: 월별 재정 요약 페이지 반응형 추가

### DIFF
--- a/src/components/summary/CategoryDonutChart.vue
+++ b/src/components/summary/CategoryDonutChart.vue
@@ -184,7 +184,7 @@ const emitHoverCategory = (categoryId, event) => {
 
 .donut-card__body {
   display: grid;
-  grid-template-columns: 256px minmax(0, 1fr);
+  grid-template-columns: minmax(220px, 256px) minmax(0, 1fr);
   gap: 18px;
   align-items: center;
   margin-top: 14px;
@@ -192,8 +192,9 @@ const emitHoverCategory = (categoryId, event) => {
 
 .category-donut-chart {
   position: relative;
-  width: 256px;
-  height: 248px;
+  width: min(100%, 256px);
+  aspect-ratio: 1 / 1;
+  height: auto;
   margin: 0 auto;
 }
 
@@ -220,7 +221,7 @@ const emitHoverCategory = (categoryId, event) => {
 
 .category-donut-chart__center {
   position: absolute;
-  inset: 64px;
+  inset: clamp(56px, 25%, 64px);
   border-radius: 50%;
   background: #ffffff;
   display: flex;
@@ -289,9 +290,10 @@ const emitHoverCategory = (categoryId, event) => {
   color: var(--black-2);
   font-size: 15px;
   font-weight: 700;
+  word-break: keep-all;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .donut-card {
     min-height: auto;
     padding: 20px 18px 18px;
@@ -303,12 +305,11 @@ const emitHoverCategory = (categoryId, event) => {
   }
 
   .category-donut-chart {
-    width: 248px;
-    height: 248px;
+    width: min(100%, 240px);
   }
 
   .category-donut-chart__center {
-    inset: 64px;
+    inset: clamp(56px, 26%, 62px);
   }
 }
 </style>

--- a/src/components/summary/TrendBarChart.vue
+++ b/src/components/summary/TrendBarChart.vue
@@ -20,7 +20,10 @@
       <div v-for="item in monthlyData" :key="item.monthKey" class="trend-chart__group">
         <div
           class="trend-chart__bars"
-          :class="{ 'trend-chart__bars--single': getRenderedSeries(item).length === 1 }"
+          :class="{
+            'trend-chart__bars--single': getRenderedSeries(item).length === 1,
+            'trend-chart__bars--dense': getRenderedSeries(item).length >= 3,
+          }"
         >
           <div
             v-for="series in getRenderedSeries(item)"
@@ -130,7 +133,6 @@ const getBarStyle = (value, color) => {
 
 const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}원`
 </script>
-
 <style scoped>
 @import '@/assets/color.css';
 
@@ -153,7 +155,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 .trend-card__title {
   margin: 0;
   color: var(--black-1);
-  font-size: 24px;
+  font-size: clamp(20px, 1.8vw, 24px);
   font-weight: 800;
 }
 
@@ -205,7 +207,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   justify-content: center;
   gap: 16px;
   align-items: stretch;
-  padding: 14px 20px 0;
+  padding: 14px clamp(12px, 1.4vw, 20px) 0;
   border-radius: 24px;
   background:
     linear-gradient(to top, rgba(23, 25, 28, 0.04) 1px, transparent 1px) 0 100% / 100% 25%,
@@ -226,7 +228,7 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
 }
 
 .trend-chart__bar {
-  width: 30px;
+  width: clamp(18px, 2.1vw, 30px);
   max-width: 100%;
   border-radius: 10px 10px 4px 4px;
   min-height: 6px;
@@ -329,28 +331,42 @@ const formatCurrency = (value) => `${Number(value ?? 0).toLocaleString('ko-KR')}
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .trend-card {
     min-height: auto;
-    padding: 18px 18px 14px;
+    padding: 16px 16px 12px;
   }
 
   .trend-card__header {
     flex-direction: column;
+    gap: 12px;
   }
 
   .trend-chart {
-    gap: 10px;
-    min-height: 230px;
+    gap: 8px;
+    min-height: 214px;
+  }
+
+  .trend-chart__group {
+    gap: 8px;
   }
 
   .trend-chart__bars {
-    min-height: 188px;
-    padding: 14px 16px 0;
+    min-height: 172px;
+    gap: 8px;
+    padding: 12px 8px 0;
   }
 
   .trend-chart__bar {
-    width: 24px;
+    width: 20px;
+  }
+
+  .trend-chart__bars--dense .trend-chart__bar {
+    width: 16px;
+  }
+
+  .trend-chart__label {
+    font-size: 12px;
   }
 }
 </style>

--- a/src/pages/SummaryView.vue
+++ b/src/pages/SummaryView.vue
@@ -385,7 +385,7 @@ onMounted(() => {
   overflow: visible;
   display: grid;
   gap: 12px;
-  padding-right: 4px;
+  padding-inline: 4px;
   padding-bottom: 8px;
 }
 
@@ -399,7 +399,7 @@ onMounted(() => {
 
 .summary-content {
   display: grid;
-  grid-template-columns: minmax(0, 1.28fr) minmax(372px, 0.92fr);
+  grid-template-columns: minmax(0, 1.28fr) minmax(320px, 0.92fr);
   gap: 18px;
   align-items: start;
 }
@@ -453,7 +453,7 @@ onMounted(() => {
 
 .monthly-summary-card {
   display: grid;
-  grid-template-columns: 64px minmax(0, 1fr) 160px 160px;
+  grid-template-columns: 64px minmax(0, 1fr) minmax(132px, 160px) minmax(132px, 160px);
   align-items: center;
   gap: 14px;
   padding: 18px 22px;
@@ -567,13 +567,13 @@ onMounted(() => {
 
 .category-row__name {
   color: var(--black-1);
-  font-size: 19px;
+  font-size: clamp(16px, 1.2vw, 19px);
   font-weight: 700;
 }
 
 .category-row__amount {
   color: var(--black-1);
-  font-size: 19px;
+  font-size: clamp(16px, 1.2vw, 19px);
   font-weight: 800;
 }
 
@@ -589,7 +589,7 @@ onMounted(() => {
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
   .summary-toolbar {
     align-items: stretch;
     flex-direction: column;
@@ -604,8 +604,38 @@ onMounted(() => {
     padding: 16px 18px;
   }
 
+  .monthly-summary-card__title {
+    font-size: 16px;
+  }
+
+  .monthly-summary-card__metric {
+    grid-column: 2 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .monthly-summary-card__label {
+    margin-bottom: 0;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .monthly-summary-card__income,
+  .monthly-summary-card__expense {
+    font-size: 16px;
+    white-space: nowrap;
+  }
+
   .category-row {
     padding: 13px 12px;
+  }
+
+  .category-row__name,
+  .category-row__amount {
+    font-size: 16px;
+    word-break: keep-all;
   }
 }
 </style>


### PR DESCRIPTION
## 📄 PR 요약
> 월별 재정 요약 페이지에 반응형 디자인을 추가했습니다.

## ✍🏻 PR 상세
1. SummaryView 레이아웃 고정 폭을 완화해 화면 크기에 따라 유연하게 배치되도록 수정했습니다.
2. TrendBarChart의 막대/헤더 스타일을 조정해 좁은 화면에서 차트 폭을 줄이는 등 가독성을 개선했습니다.
3. CategoryDonutChart의 도넛 크기와 중앙 영역을 유동적으로 변경했습니다.

## 👀 참고사항
- 각자 화면에서 확인해주시면 감사하겠습니다... 요소가 많아서 너무 어렵네요 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
#45
