### PR TITLE
fix: summary 탭-차트 간격 정리

### DIFF
--- a/src/pages/SummaryView.vue
+++ b/src/pages/SummaryView.vue
@@ -2,27 +2,29 @@
   <section ref="summaryViewRef" class="summary-view">
     <ComparisonTooltip :comparison="hoveredComparison" :position="tooltipPosition" />
 
-    <div class="summary-toolbar">
-      <div class="metric-toggle" role="tablist" aria-label="지표 선택">
-        <button
-          v-for="type in metricTypes"
-          :key="type.value"
-          type="button"
-          class="metric-toggle__button"
-          :class="{ 'metric-toggle__button--active': selectedMetric === type.value }"
-          @click="handleMetricClick(type.value)"
-        >
-          {{ type.label }}
-        </button>
-      </div>
-    </div>
-
     <div class="summary-content">
       <section class="summary-content__left">
-        <TrendBarChart
-          :monthly-data="recentThreeMonthStats"
-          :selected-metric="selectedMetric"
-        />
+        <div class="summary-trend-block">
+          <div class="summary-toolbar">
+            <div class="metric-toggle" role="tablist" aria-label="지표 선택">
+              <button
+                v-for="type in metricTypes"
+                :key="type.value"
+                type="button"
+                class="metric-toggle__button"
+                :class="{ 'metric-toggle__button--active': selectedMetric === type.value }"
+                @click="handleMetricClick(type.value)"
+              >
+                {{ type.label }}
+              </button>
+            </div>
+          </div>
+
+          <TrendBarChart
+            :monthly-data="recentThreeMonthStats"
+            :selected-metric="selectedMetric"
+          />
+        </div>
 
         <div class="monthly-summary-list">
           <article
@@ -409,6 +411,11 @@ onMounted(() => {
   display: grid;
   gap: 14px;
   align-content: start;
+}
+
+.summary-trend-block {
+  display: grid;
+  gap: 8px;
 }
 
 .metric-toggle {


### PR DESCRIPTION
## 📄 PR 요약
> Summary 페이지에서 지표 탭(전체/수입/지출/순이익)과 차트 영역 간 간격이 환경별로 다르게 보이던 문제를 수정했습니다.

## ✍🏻 PR 상세
1. `SummaryView`에서 탭과 `TrendBarChart`를 같은 블록(`summary-trend-block`)으로 묶어 간격 기준을 통일했습니다.
2. 기존 구조는 유지하고, 레이아웃 간격만 최소 수정했습니다.

## 👀 참고사항
- 로직 변경 없음 (UI 레이아웃/간격 조정만 포함)
- 맥 환경에서 확인부탁드려요!  제 노트북으로는 확인이 안됩니다.

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
#45
