### PR TITLE
design : 소비레이스 ui 개선

### DIFF
--- a/src/components/group/RaceTrack.vue
+++ b/src/components/group/RaceTrack.vue
@@ -2,11 +2,11 @@
   <section class="race-track-wrap">
     <header class="race-header">
       <h2 class="fw-black text-black-1 header-title">
-        👑 이달의 거지왕: {{ groupStore.maxRunner.name }} 👑
+        👑 이달의 거지왕: {{ groupStore.minRunner.name }} 👑
       </h2>
 
       <div class="goal-box">
-        <p class="fw-bold text-black-2 goal-label">그룹 코드 {{ groupStore.currentGroup.id }}</p>
+        <p class="fw-bold text-black-2 goal-label">그룹 코드 : {{ groupStore.currentGroup.id }}</p>
         <p class="fw-black text-red-1 goal-amount">
           {{ toWon(groupStore.currentGroup.targetAmount) }}
         </p>
@@ -25,30 +25,90 @@
       </div>
 
       <div class="lane-wrap">
-        <div class="lane bg-black-3"></div>
-        <div
-          v-for="runner in groupStore.runners"
-          :key="runner.userId"
-          class="runner"
-          :style="{ left: `${runner.position}%` }"
-        >
-          <span class="fw-bold value-chip" :class="runner.danger ? 'chip-danger' : 'chip-normal'">
-            {{ toWon(runner.amount) }}
-          </span>
-          <div class="profileImg-wrap">
-            <div class="profileImg">{{ runner.profileImg }}</div>
-            <img
-              class="status-icon"
-              :src="runner.amount > groupStore.currentGroup.targetAmount ? SkullIcon : SmileIcon"
-              alt=""
-            />
+        <div class="lane bg-black-3">
+          <div class="lane-start-flag" aria-hidden="true"></div>
+          <div class="lane-limit" :style="{ left: `${groupStore.limitPosition}%` }">
+            <span class="fw-bold lane-limit-label">
+              LIMIT: {{ toWon(groupStore.currentGroup.targetAmount) }}
+            </span>
           </div>
-          <p class="fw-bold text-black-1 runner-name" :class="{ 'text-red-1': runner.danger }">
-            {{ runner.name }}
-          </p>
+        </div>
+        <div
+          v-for="group in groupedRunners"
+          :key="group.key"
+          class="runner"
+          :style="{ left: `${group.position}%` }"
+        >
+          <template v-if="group.count === 1">
+            <span
+              class="fw-bold value-chip"
+              :class="group.runner.danger ? 'chip-danger' : 'chip-normal'"
+            >
+              {{ toWon(group.runner.amount) }}
+            </span>
+            <div class="profileImg-wrap">
+              <div class="profileImg" :style="{ backgroundColor: getRunnerTone(group.runner.amount) }">
+                {{ group.runner.profileImg }}
+              </div>
+            </div>
+            <p
+              class="fw-bold runner-name"
+              :style="{ color: group.runner.danger ? 'var(--red-1)' : 'var(--black-1)' }"
+            >
+              {{ group.runner.name }}
+            </p>
+            <div class="status-icon-wrap">
+              <img
+                class="status-icon"
+                :src="
+                  group.runner.amount > groupStore.currentGroup.targetAmount ? SkullIcon : SmileIcon
+                "
+                alt=""
+              />
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="cluster-chip-row">
+              <span
+                v-for="member in group.runners"
+                :key="`${member.userId}-chip`"
+                class="fw-bold value-chip"
+                :class="member.danger ? 'chip-danger' : 'chip-normal'"
+              >
+                {{ toWon(member.amount) }}
+              </span>
+            </div>
+
+            <div class="cluster-stack">
+              <div
+                v-for="(member, idx) in group.runners.slice(0, 3)"
+                :key="`${member.userId}-bubble`"
+                class="cluster-orb"
+                :style="getClusterOrbStyle(member.amount, idx, group.count)"
+              >
+                <div
+                  class="cluster-orb-inner"
+                  :style="{ backgroundColor: getRunnerTone(member.amount) }"
+                >
+                  {{ member.profileImg }}
+                </div>
+              </div>
+            </div>
+
+            <div class="cluster-names">
+              <span
+                v-for="member in group.runners"
+                :key="`${member.userId}-name`"
+                class="fw-bold cluster-name"
+                :style="{ color: member.danger ? 'var(--red-1)' : 'var(--black-1)' }"
+              >
+                {{ member.name }}
+              </span>
+            </div>
+          </template>
         </div>
 
-        <div class="limit-line" :style="{ left: `${groupStore.limitPosition}%` }"></div>
         <span
           class="fw-bold text-black-4 limit-pill"
           :style="{ left: `${groupStore.limitPosition}%` }"
@@ -65,11 +125,11 @@
       <div class="legend bg-yellow-2">
         <div class="legend-item">
           <img :src="SmileIcon" width="15" height="15" alt="safe" />
-          <span class="fw-medium text-black-1">안전 구역 (거지왕 후보)</span>
+          <span class="fw-medium text-black-1">안전 뱃지 (거지왕 후보)</span>
         </div>
         <div class="legend-item">
           <img :src="SkullIcon" width="15" height="15" alt="danger" />
-          <span class="fw-medium text-black-1">파산 구역 (과소비 경고)</span>
+          <span class="fw-medium text-black-1">파산 뱃지 (과소비 경고)</span>
         </div>
       </div>
     </article>
@@ -77,6 +137,7 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import SkullIcon from '@/assets/icons/group/group-skull.png'
 import SmileIcon from '@/assets/icons/group/group-smile.png'
 import { useAuthStore } from '@/stores/useAuthStore'
@@ -86,6 +147,7 @@ import { useUserStore } from '@/stores/useUserStore'
 const authStore = useAuthStore()
 const groupStore = useGroupStore()
 const userStore = useUserStore()
+const overlapThreshold = 8
 
 // 금액을 원 단위로 포맷팅하는 method
 const toWon = (value) => `${value.toLocaleString('ko-KR')} 원`
@@ -102,6 +164,67 @@ const onClickLeaveGroup = async () => {
   await groupStore.leaveGroup(userId, groupId)
   await userStore.updateGroupId(userId, '')
 }
+
+const getRunnerTone = (amount) => {
+  const min = groupStore.displayMin
+  const limit = groupStore.currentGroup.targetAmount
+
+  if (amount >= limit) return 'var(--orange-1)'
+
+  const ratio = limit === min ? 0 : (amount - min) / (limit - min)
+  if (ratio >= 0.75) return 'var(--yellow-1)'
+  if (ratio >= 0.5) return 'var(--yellow-2)'
+  return 'var(--green-2)'
+}
+
+const getClusterOrbStyle = (amount, index, count) => {
+  const limitedCount = Math.min(count, 3)
+  const offsets =
+    limitedCount === 2
+      ? [-18, 18]
+      : limitedCount === 3
+        ? [-24, 0, 24]
+        : [0]
+
+  return {
+    backgroundColor: getRunnerTone(amount),
+    transform: `translateX(${offsets[index] ?? 0}px)`,
+    zIndex: index + 1,
+  }
+}
+
+const groupedRunners = computed(() => {
+  const sortedRunners = [...groupStore.runners].sort((a, b) => a.position - b.position)
+  const groups = []
+  let currentGroup = []
+
+  for (const runner of sortedRunners) {
+    if (currentGroup.length === 0) {
+      currentGroup.push(runner)
+      continue
+    }
+
+    const lastRunner = currentGroup[currentGroup.length - 1]
+    if (Math.abs(runner.position - lastRunner.position) < overlapThreshold) {
+      currentGroup.push(runner)
+    } else {
+      groups.push(currentGroup)
+      currentGroup = [runner]
+    }
+  }
+
+  if (currentGroup.length) {
+    groups.push(currentGroup)
+  }
+
+  return groups.map((group) => ({
+    key: group.map((runner) => runner.userId).join('-'),
+    count: group.length,
+    position: group.reduce((sum, runner) => sum + runner.position, 0) / group.length,
+    runners: group,
+    runner: group[0],
+  }))
+})
 </script>
 
 <style scoped>
@@ -124,11 +247,21 @@ const onClickLeaveGroup = async () => {
   width: fit-content;
 }
 .status-icon {
-  position: absolute;
-  right: 0px;
-  bottom: 16px;
   width: 16px;
   height: 16px;
+}
+
+.status-icon-wrap {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  bottom: 18px;
+  left: 45px;
+  background-color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .header-title {
@@ -226,19 +359,93 @@ const onClickLeaveGroup = async () => {
 }
 
 .lane {
+  position: relative;
   width: 100%;
   height: 46px;
   border-radius: 999px;
+  overflow: hidden;
+}
+
+.lane-start-flag {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 22px;
+  border-radius: 999px 0 0 999px;
+  background-image:
+    linear-gradient(45deg, var(--black-1) 25%, transparent 25%, transparent 75%, var(--black-1) 75%, var(--black-1)),
+    linear-gradient(45deg, var(--black-1) 25%, transparent 25%, transparent 75%, var(--black-1) 75%, var(--black-1));
+  background-position: 0 0, 6px 6px;
+  background-size: 12px 12px;
+  background-color: var(--black-4);
+  opacity: 0.95;
+  z-index: 1;
 }
 
 .runner {
   position: absolute;
   top: 0;
   transform: translateX(-50%);
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
+}
+
+.lane-limit {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  transform: translateX(-50%);
+  border-left: 3px dashed var(--red-1);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.lane-limit-label {
+  position: absolute;
+  left: 50%;
+  bottom: -28px;
+  transform: translateX(-50%);
+  color: var(--red-1);
+  font-size: 10px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.limit-pill {
+  position: absolute;
+  bottom: -34px;
+  transform: translateX(-50%);
+  background-color: var(--red-1);
+  color: var(--black-4);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 10px;
+  white-space: nowrap;
+  z-index: 3;
+}
+
+.limit-pill::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: -9px;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 9px solid var(--red-1);
+}
+
+.cluster-chip-row {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  flex-wrap: nowrap;
 }
 
 .value-chip {
@@ -259,10 +466,9 @@ const onClickLeaveGroup = async () => {
 }
 
 .profileImg {
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   border-radius: 999px;
-  background-color: var(--black-3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -274,25 +480,49 @@ const onClickLeaveGroup = async () => {
   font-size: 12px;
 }
 
-.limit-line {
-  position: absolute;
-  top: 20px;
-  bottom: 18px;
-  width: 3px;
-  background-color: var(--red-1);
-  border-radius: 999px;
-  transform: translateX(-50%);
+.cluster-stack {
+  position: relative;
+  width: 92px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.limit-pill {
+.cluster-orb {
   position: absolute;
-  bottom: 0;
-  transform: translateX(-50%);
-  background-color: var(--red-1);
-  color: var(--black-4);
+  width: 60px;
+  height: 60px;
   border-radius: 999px;
-  padding: 4px 9px;
-  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 18px rgba(23, 25, 28, 0.08);
+}
+
+.cluster-orb-inner {
+  width: 38px;
+  height: 38px;
+  background-color: white;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+}
+
+.cluster-names {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+  max-width: 110px;
+  text-align: center;
+  line-height: 1.25;
+}
+
+.cluster-name {
+  font-size: 12px;
 }
 
 .scale-row {

--- a/src/components/group/RankingBoard.vue
+++ b/src/components/group/RankingBoard.vue
@@ -52,7 +52,7 @@ const safeRows = computed(() => {
 const dangerRows = computed(() => {
   return rankedRunners.value.filter((runner) => runner.danger === true)
 })
-const toWon = (value) => `${value.toLocaleString('ko-KR')} ₩`
+const toWon = (value) => `${value.toLocaleString('ko-KR')} 원`
 </script>
 
 <style scoped>


### PR DESCRIPTION
## 📄 PR 요약
> RaceTrack UI를 개선하고, 동일/유사 위치에 있는 러너들을 그룹으로 묶어 겹침 없이 표시할 수 있도록 수정했습니다.  
> 또한 랭킹보드와 트랙 내 금액 표기 방식을 `원` 단위로 통일했습니다.

## ✍🏻 PR 상세
1. RaceTrack 상단 문구를 최대 소비자 기준에서 최소 소비자 기준으로 수정했습니다.
   - `maxRunner.name` → `minRunner.name`
   - “이달의 거지왕” 문구와 실제 의도가 일치하도록 반영했습니다.

2. 그룹 코드 및 한도 표시 UI를 더 명확하게 수정했습니다.
   - `그룹 코드 :` 형태로 텍스트를 정리했습니다.
   - 트랙 내부에 시작 지점 플래그와 LIMIT 표시를 추가해 한도 기준을 직관적으로 확인할 수 있도록 개선했습니다.

3. 러너 겹침 문제를 해결하기 위해 그룹화 로직을 추가했습니다.
   - `groupStore.runners`를 그대로 출력하던 방식에서,
     위치 차이가 일정 기준 이하인 러너들을 하나의 그룹으로 묶어 렌더링하도록 변경했습니다.
   - `groupedRunners` computed를 추가해 겹치는 러너들을 하나의 클러스터처럼 보여줄 수 있도록 처리했습니다.

4. 단일 러너와 중첩 러너의 UI를 분리했습니다.
   - 혼자 있는 러너는 기존처럼 금액, 프로필, 이름, 상태 아이콘을 표시합니다.
   - 여러 명이 겹치는 경우에는
     - 금액 칩 목록
     - 겹쳐진 프로필 오브
     - 이름 목록
     형태로 시각적으로 구분되도록 구현했습니다.

5. 소비 금액에 따라 러너/클러스터의 톤이 달라지도록 스타일 로직을 추가했습니다.
   - `getRunnerTone`
   - `getClusterOrbStyle`
   를 통해 금액 수준에 따른 배경색과 배치 스타일을 적용했습니다.

6. 범례 문구를 실제 UI 의미에 맞게 수정했습니다.
   - “안전 구역” → “안전 뱃지”
   - “파산 구역” → “파산 뱃지”

7. 금액 포맷을 전체적으로 통일했습니다.
   - `₩` 표기를 `원`으로 변경해 RaceTrack, RankingBoard 모두 동일한 포맷을 사용하도록 수정했습니다.

## 👀 참고사항
- 러너 그룹화 기준은 `overlapThreshold = 8`로 설정했습니다.
- 4명 이상이 겹치는 경우에도 클러스터 형태로 묶이지만, 프로필 오브 표시는 최대 3명까지 노출됩니다.
- 스타일 변경 범위가 커서 실제 화면에서 러너 위치, 클러스터 정렬, LIMIT 라벨 위치 확인이 필요합니다.

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #79 