### PR TITLE
fix: 메인 레이아웃 높이 최적화 및 모바일 뷰포트 대응 (100dvh 적용)

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -39,7 +39,7 @@ provide('isMobile', isMobile)
 <style scoped>
 .container {
   width: 100%;
-  height: 100%;
+  height: 100dvh;
   min-height: 100dvh;
   background-color: #f9fafa;
   padding: 0;
@@ -55,6 +55,7 @@ provide('isMobile', isMobile)
   margin-left: 320px;
   padding: 72px 48px;
   box-sizing: border-box;
+  min-height: 100dvh;
 }
 
 .router-container.mobile {


### PR DESCRIPTION
## 📄 PR 요약
> 모바일 브라우저(Safari, Chrome 등)에서 하단 바나 주소창 유무에 따라 레이아웃이 끊기거나 잘리던 현상을 수정했습니다.
> MainLayout.vue의 전체 컨테이너 높이 단위를 개선하여 모든 디바이스에서 화면이 꽉 차도록 최적화했습니다.

## ✍🏻 PR 상세
1. MainLayout.vue
- .container 클래스의 height 및 min-height 단위를 100%에서 100dvh (Dynamic Viewport Height)로 변경
- 이를 통해 모바일 환경에서 주소창의 동적 변화에 맞춰 화면 높이가 유연하게 조정되도록 구현

## 👀 참고사항
- 기존 팀원분이 작성하신 반응형 틀과 컴포넌트 구조는 건드리지 않고, 높이 관련 CSS 속성만 수정하였니다.
- 데스크탑과 모바일 환경 모두에서 레이아웃이 의도한 대로 꽉 차게 출력되는 것을 확인했습니다.

## ✅ 체크리스트
- [x] 모바일 브라우저 주소창 변화에 따른 하단 잘림 현상 해결 여부
- [x] 다른 페이지 컴포넌트와의 레이아웃 간섭 여부 (영향 없음 확인)

## 🚪 연관된 이슈 번호
Closes #83 
