### PR TITLE
refactor:Summary 집계 로직 정리

### DIFF
--- a/src/pages/SummaryView.vue
+++ b/src/pages/SummaryView.vue
@@ -142,7 +142,6 @@ const highlightedCategoryId = ref(null)
 const tooltipPosition = ref({ x: 0, y: 0 })
 
 const parseMonthKey = (dateString) => String(dateString).slice(0, 7)
-const shortMonthLabel = (monthKey) => `${Number(monthKey.split('-')[1])}월`
 
 const shiftMonthKey = (monthKey, diff) => {
   const [year, month] = monthKey.split('-').map(Number)
@@ -164,59 +163,12 @@ const latestRangeMonthKey = computed(() => {
   }, parseMonthKey(transactions.value[0].date))
 })
 
-const monthlyAggregation = computed(() => {
-  const byMonth = new Map()
-
-  transactions.value.forEach((tx) => {
-    const monthKey = parseMonthKey(tx.date)
-    const amount = Number(tx.amount || 0)
-
-    if (!byMonth.has(monthKey)) {
-      byMonth.set(monthKey, {
-        income: 0,
-        expense: 0,
-        expenseByCategory: new Map(),
-      })
-    }
-
-    const monthData = byMonth.get(monthKey)
-    if (tx.type === 'income') {
-      monthData.income += amount
-      return
-    }
-
-    if (tx.type === 'expense') {
-      monthData.expense += amount
-
-      if (tx.categoryId) {
-        const prevAmount = monthData.expenseByCategory.get(tx.categoryId) ?? 0
-        monthData.expenseByCategory.set(tx.categoryId, prevAmount + amount)
-      }
-    }
-  })
-
-  return byMonth
-})
+const monthlyAggregation = computed(() => transactionStore.monthlyAggregation)
 
 // 선택된 월을 기준으로 최근 3개월의 수입/지출/순이익 통계
-const recentThreeMonthStats = computed(() => {
-  if (!selectedMonthKey.value) return []
-
-  return [2, 1, 0].map((diff) => {
-    const monthKey = shiftMonthKey(selectedMonthKey.value, -diff)
-    const monthData = monthlyAggregation.value.get(monthKey)
-    const income = monthData?.income ?? 0
-    const expense = monthData?.expense ?? 0
-
-    return {
-      monthKey,
-      label: shortMonthLabel(monthKey),
-      income,
-      expense,
-      net: income - expense,
-    }
-  })
-})
+const recentThreeMonthStats = computed(() =>
+  transactionStore.getThreeMonthStats(selectedMonthKey.value),
+)
 
 const monthlySummaryCards = computed(() =>
   recentThreeMonthStats.value.map((item, index, array) => ({

--- a/src/stores/useTransactionStore.js
+++ b/src/stores/useTransactionStore.js
@@ -63,6 +63,64 @@ export const useTransactionStore = defineStore('transaction', {
         (tx) => dayjs(tx.date).format('YYYY-MM-DD') === state.selectedDate,
       )
     },
+
+    // 기간 데이터(rangeTransactions)를 월 단위로 집계
+    monthlyAggregation(state) {
+      const byMonth = new Map()
+
+      state.rangeTransactions.forEach((tx) => {
+        const monthKey = String(tx.date).slice(0, 7)
+        const amount = Number(tx.amount || 0)
+
+        if (!byMonth.has(monthKey)) {
+          byMonth.set(monthKey, {
+            income: 0,
+            expense: 0,
+            expenseByCategory: new Map(),
+          })
+        }
+
+        const monthData = byMonth.get(monthKey)
+        if (tx.type === 'income') {
+          monthData.income += amount
+          return
+        }
+
+        if (tx.type === 'expense') {
+          monthData.expense += amount
+
+          if (tx.categoryId) {
+            const prevAmount = monthData.expenseByCategory.get(tx.categoryId) ?? 0
+            monthData.expenseByCategory.set(tx.categoryId, prevAmount + amount)
+          }
+        }
+      })
+
+      return byMonth
+    },
+
+    // 기준 월(baseMonthKey) 기준 최근 3개월 통계
+    getThreeMonthStats() {
+      return (baseMonthKey) => {
+        if (!baseMonthKey) return []
+
+        return [2, 1, 0].map((diff) => {
+          const targetDate = dayjs(`${baseMonthKey}-01`).subtract(diff, 'month')
+          const monthKey = targetDate.format('YYYY-MM')
+          const monthData = this.monthlyAggregation.get(monthKey)
+          const income = monthData?.income ?? 0
+          const expense = monthData?.expense ?? 0
+
+          return {
+            monthKey,
+            label: `${targetDate.month() + 1}월`,
+            income,
+            expense,
+            net: income - expense,
+          }
+        })
+      }
+    },
   },
 
   actions: {


### PR DESCRIPTION
## 📄 PR 요약
> SummaryView의 월별/3개월 집계 비즈니스 로직을 store로 분리합니다.

## ✍🏻 PR 상세
1. SummaryView의 중복 집계 로직을 useTransactionStore 사용 방식으로 단순화합니다.

## 👀 참고사항
- 없습니다.

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #85
