### PR TITLE
bugfix : 소비레이스 limit 초과 버그 및 그룹 레이스 참여, 생성, 탈퇴 시 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -558,12 +558,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",

--- a/src/components/group/GroupManager.vue
+++ b/src/components/group/GroupManager.vue
@@ -116,7 +116,7 @@ const onClickJoin = async () => {
   await groupStore.joinGroup(userId, joinCode.value)
   const groupId = groupStore.currentGroup.id
   await userStore.updateGroupId(userId, groupId)
-
+  await groupStore.loadGroup(groupId)
   closePanel()
 }
 
@@ -125,6 +125,7 @@ const onClickCreate = async () => {
   await groupStore.addGroup(userId, groupName.value, targetAmount.value)
   const groupId = groupStore.currentGroup.id
   await userStore.updateGroupId(userId, groupId)
+  await groupStore.loadGroup(groupId)
   closePanel()
 }
 </script>

--- a/src/components/group/RaceTrack.vue
+++ b/src/components/group/RaceTrack.vue
@@ -2,7 +2,7 @@
   <section class="race-track-wrap">
     <header class="race-header">
       <h2 class="fw-black text-black-1 header-title">
-        👑 이달의 거지왕: {{ groupStore.minRunner.name }} 👑
+        👑 이달의 거지왕: {{ groupStore.maxRunner.name }} 👑
       </h2>
 
       <div class="goal-box">
@@ -47,7 +47,10 @@
               {{ toWon(group.runner.amount) }}
             </span>
             <div class="profileImg-wrap">
-              <div class="profileImg" :style="{ backgroundColor: getRunnerTone(group.runner.amount) }">
+              <div
+                class="profileImg"
+                :style="{ backgroundColor: getRunnerTone(group.runner.amount) }"
+              >
                 {{ group.runner.profileImg }}
               </div>
             </div>
@@ -179,12 +182,7 @@ const getRunnerTone = (amount) => {
 
 const getClusterOrbStyle = (amount, index, count) => {
   const limitedCount = Math.min(count, 3)
-  const offsets =
-    limitedCount === 2
-      ? [-18, 18]
-      : limitedCount === 3
-        ? [-24, 0, 24]
-        : [0]
+  const offsets = limitedCount === 2 ? [-18, 18] : limitedCount === 3 ? [-24, 0, 24] : [0]
 
   return {
     backgroundColor: getRunnerTone(amount),
@@ -374,9 +372,25 @@ const groupedRunners = computed(() => {
   width: 22px;
   border-radius: 999px 0 0 999px;
   background-image:
-    linear-gradient(45deg, var(--black-1) 25%, transparent 25%, transparent 75%, var(--black-1) 75%, var(--black-1)),
-    linear-gradient(45deg, var(--black-1) 25%, transparent 25%, transparent 75%, var(--black-1) 75%, var(--black-1));
-  background-position: 0 0, 6px 6px;
+    linear-gradient(
+      45deg,
+      var(--black-1) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--black-1) 75%,
+      var(--black-1)
+    ),
+    linear-gradient(
+      45deg,
+      var(--black-1) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--black-1) 75%,
+      var(--black-1)
+    );
+  background-position:
+    0 0,
+    6px 6px;
   background-size: 12px 12px;
   background-color: var(--black-4);
   opacity: 0.95;

--- a/src/components/group/RaceTrack.vue
+++ b/src/components/group/RaceTrack.vue
@@ -27,7 +27,11 @@
       <div class="lane-wrap">
         <div class="lane bg-black-3">
           <div class="lane-start-flag" aria-hidden="true"></div>
-          <div class="lane-limit" :style="{ left: `${groupStore.limitPosition}%` }">
+          <div
+            class="lane-limit"
+            :class="{ 'lane-limit-overflow': isLimitOverflow }"
+            :style="{ left: `${limitDisplayPosition}%` }"
+          >
             <span class="fw-bold lane-limit-label">
               LIMIT: {{ toWon(groupStore.currentGroup.targetAmount) }}
             </span>
@@ -114,7 +118,8 @@
 
         <span
           class="fw-bold text-black-4 limit-pill"
-          :style="{ left: `${groupStore.limitPosition}%` }"
+          :class="{ 'limit-pill-overflow': isLimitOverflow }"
+          :style="{ left: `${limitDisplayPosition}%` }"
         >
           LIMIT: {{ toWon(groupStore.currentGroup.targetAmount) }}
         </span>
@@ -190,6 +195,12 @@ const getClusterOrbStyle = (amount, index, count) => {
     zIndex: index + 1,
   }
 }
+
+const isLimitOverflow = computed(
+  () => groupStore.currentGroup.targetAmount > groupStore.displayMax && groupStore.displayMax > 0,
+)
+
+const limitDisplayPosition = computed(() => (isLimitOverflow.value ? 90 : groupStore.limitPosition))
 
 const groupedRunners = computed(() => {
   const sortedRunners = [...groupStore.runners].sort((a, b) => a.position - b.position)
@@ -418,6 +429,10 @@ const groupedRunners = computed(() => {
   pointer-events: none;
 }
 
+.lane-limit.lane-limit-overflow {
+  display: none;
+}
+
 .lane-limit-label {
   position: absolute;
   left: 50%;
@@ -453,6 +468,17 @@ const groupedRunners = computed(() => {
   border-left: 9px solid transparent;
   border-right: 9px solid transparent;
   border-bottom: 9px solid var(--red-1);
+}
+
+.limit-pill.limit-pill-overflow::before {
+  left: auto;
+  right: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left: 13px solid var(--red-1);
+  border-right: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
 }
 
 .cluster-chip-row {

--- a/src/pages/GroupRaceView.vue
+++ b/src/pages/GroupRaceView.vue
@@ -31,9 +31,17 @@ const transactionStore = useTransactionStore()
 const isLoading = ref(true)
 
 onMounted(async () => {
+  await userStore.fetchUserData(AuthStore.currentUserId)
+  if (
+    !userStore.userData.groupId ||
+    userStore.userData.groupId === 'empty' ||
+    userStore.userData.groupId === ''
+  ) {
+    isLoading.value = false
+    return
+  }
   try {
     //data loading
-    await userStore.fetchUserData(AuthStore.currentUserId)
     const groupId = userStore.userData.groupId
     await groupStore.loadGroup(groupId)
     const memberIds = groupStore.currentGroup.memberIds

--- a/src/pages/GroupRaceView.vue
+++ b/src/pages/GroupRaceView.vue
@@ -22,7 +22,7 @@ import { useAuthStore } from '@/stores/useAuthStore'
 import { useGroupStore } from '@/stores/useGroupStore'
 import { useTransactionStore } from '@/stores/useTransactionStore'
 import { useUserStore } from '@/stores/useUserStore'
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
 const userStore = useUserStore()
 const AuthStore = useAuthStore()
@@ -30,30 +30,38 @@ const groupStore = useGroupStore()
 const transactionStore = useTransactionStore()
 const isLoading = ref(true)
 
+watch(
+  () => userStore.userData.groupId,
+
+  async (newGroupId) => {
+    if (
+      !userStore.userData.groupId ||
+      userStore.userData.groupId === 'empty' ||
+      userStore.userData.groupId === ''
+    ) {
+      isLoading.value = false
+      return
+    }
+
+    try {
+      //data loading
+      await groupStore.loadGroup(newGroupId)
+      const memberIds = groupStore.currentGroup.memberIds
+
+      // memberIds로 transactionStore 접근해서 runners의 지출액 데이터 가져오기
+      const runnersExpenses = await transactionStore.fetchGroupRunners(memberIds)
+      // runners 배열에 userStore에서 userId로 이름, 아바타 이미지 조회해서 추가
+      const runnersInfo = await userStore.fetchUsersInfo(memberIds)
+      // runners 배열에 지출액, 이름, 아바타 이미지 및 필요한 데이터 합치기
+      groupStore.getRunnersDetails(runnersExpenses, runnersInfo)
+    } finally {
+      isLoading.value = false
+    }
+  },
+  { immediate: true },
+)
+
 onMounted(async () => {
   await userStore.fetchUserData(AuthStore.currentUserId)
-  if (
-    !userStore.userData.groupId ||
-    userStore.userData.groupId === 'empty' ||
-    userStore.userData.groupId === ''
-  ) {
-    isLoading.value = false
-    return
-  }
-  try {
-    //data loading
-    const groupId = userStore.userData.groupId
-    await groupStore.loadGroup(groupId)
-    const memberIds = groupStore.currentGroup.memberIds
-
-    // memberIds로 transactionStore 접근해서 runners의 지출액 데이터 가져오기
-    const runnersExpenses = await transactionStore.fetchGroupRunners(memberIds)
-    // runners 배열에 userStore에서 userId로 이름, 아바타 이미지 조회해서 추가
-    const runnersInfo = await userStore.fetchUsersInfo(memberIds)
-    // runners 배열에 지출액, 이름, 아바타 이미지 및 필요한 데이터 합치기
-    groupStore.getRunnersDetails(runnersExpenses, runnersInfo)
-  } finally {
-    isLoading.value = false
-  }
 })
 </script>


### PR DESCRIPTION
## 📄 PR 요약
- 그룹 참여/생성/탈퇴 후 그룹 레이스 화면이 최신 상태로 다시 렌더링되도록 데이터 갱신 흐름을 보완하고, LIMIT 표시가 범위를 초과할 때 UI가 겹치지 않도록 예외 처리를 추가했습니다.

## ✍🏻 PR 상세
- GroupRaceView에서 userStore.userData.groupId를 watch하여 그룹 변경 시 그룹 정보와 runner 데이터를 다시 불러오도록 수정했습니다.
- GroupManager의 그룹 참여/생성 이후 groupStore.loadGroup(groupId)를 호출해 현재 그룹 정보를 즉시 동기화하도록 보완했습니다.
- RaceTrack에서 LIMIT이 displayMax를 초과하는 경우 표시 위치를 90%로 고정하고, 기존 빨간 LIMIT 줄은 숨기며 말풍선 화살표를 오른쪽 방향으로 표시하도록 UI를 개선했습니다.
- 헤더의 거지왕 표시가 minRunner가 아닌 maxRunner를 바라보도록 정리했습니다.

## 👀 참고사항
- 반응형은 따로 올리겠습니다.

## ✅ 체크리스트
- [ ] PR 양식에 맞게 작성했습니다.
- [ ] 모든 테스트가 통과했습니다.
- [ ] 프로그램이 정상적으로 작동합니다.
- [ ] 적절한 라벨을 설정했습니다.
- [ ] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #81
