### PR TITLE
design : 반응형 768px race 부분 변경

### DIFF
--- a/src/components/group/GroupManager.vue
+++ b/src/components/group/GroupManager.vue
@@ -183,7 +183,11 @@ const onClickCreate = async () => {
   width: 100%;
   align-items: center;
   justify-content: flex-end;
-  margin-top: 100px;
+  margin-top: auto;
+}
+
+.btn-group .orange-btn {
+  min-width: 148px;
 }
 
 .overlay {
@@ -203,6 +207,7 @@ const onClickCreate = async () => {
 
 .popup {
   transform: translateY(-8px);
+  width: 100%;
 }
 
 .form-card {
@@ -269,6 +274,7 @@ const onClickCreate = async () => {
   align-items: center;
   justify-content: center;
   gap: 12px;
+  min-width: 148px;
 }
 
 .labeled-row {
@@ -302,21 +308,119 @@ const onClickCreate = async () => {
 
 @media (max-width: 720px) {
   .manager-wrap {
-    align-items: start;
-    padding: 24px 0 16px;
+    align-items: stretch;
+    padding: 12px 0 16px;
+  }
+
+  .stage {
+    align-items: stretch;
   }
 
   .entry-card {
     max-width: none;
+    min-height: 260px;
+    padding: 32px 24px;
+    gap: 36px;
   }
 
   .card-title {
-    font-size: 30px;
+    font-size: 24px;
   }
 
   .form-card {
     width: calc(100% - 24px);
     padding: 24px 20px 26px;
+  }
+
+  .btn-group {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    margin-top: 28px;
+  }
+
+  .btn-group .orange-btn,
+  .action-btn {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .overlay {
+    left: 0;
+    padding: 16px;
+    align-items: flex-end;
+    background-color: rgba(23, 25, 28, 0.28);
+  }
+
+  .popup {
+    transform: translateY(0);
+  }
+
+  .form-card {
+    max-width: none;
+    border-radius: 28px 28px 22px 22px;
+  }
+
+  .card-head {
+    align-items: flex-start;
+  }
+
+  .card-subtitle {
+    font-size: 14px;
+    line-height: 1.45;
+  }
+
+  .input-field {
+    height: 52px;
+    border-radius: 18px;
+    font-size: 16px;
+  }
+
+  .labeled-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .label {
+    width: auto;
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 420px) {
+  .manager-wrap {
+    padding-top: 8px;
+  }
+
+  .entry-card {
+    min-height: 240px;
+    padding: 28px 18px;
+    gap: 28px;
+  }
+
+  .title {
+    font-size: 24px;
+  }
+
+  .subtitle {
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .overlay {
+    padding: 10px;
+  }
+
+  .form-card {
+    width: 100%;
+    padding: 20px 16px 22px;
+    gap: 18px;
+  }
+
+  .close-btn {
+    width: 24px;
+    height: 24px;
   }
 }
 </style>

--- a/src/components/group/RaceTrack.vue
+++ b/src/components/group/RaceTrack.vue
@@ -44,13 +44,21 @@
           :style="{ left: `${group.position}%` }"
         >
           <template v-if="group.count === 1">
+            <div class="mobile-runner-labels">
+              <span
+                class="fw-black mobile-runner-label"
+                :style="{ backgroundColor: getRunnerTone(group.runner.amount) }"
+              >
+                {{ group.runner.profileImg }}
+              </span>
+            </div>
             <span
-              class="fw-bold value-chip"
+              class="fw-bold value-chip desktop-only"
               :class="group.runner.danger ? 'chip-danger' : 'chip-normal'"
             >
               {{ toWon(group.runner.amount) }}
             </span>
-            <div class="profileImg-wrap">
+            <div class="profileImg-wrap desktop-only">
               <div
                 class="profileImg"
                 :style="{ backgroundColor: getRunnerTone(group.runner.amount) }"
@@ -59,12 +67,12 @@
               </div>
             </div>
             <p
-              class="fw-bold runner-name"
+              class="fw-bold runner-name desktop-only"
               :style="{ color: group.runner.danger ? 'var(--red-1)' : 'var(--black-1)' }"
             >
               {{ group.runner.name }}
             </p>
-            <div class="status-icon-wrap">
+            <div class="status-icon-wrap desktop-only">
               <img
                 class="status-icon"
                 :src="
@@ -76,7 +84,18 @@
           </template>
 
           <template v-else>
-            <div class="cluster-chip-row">
+            <div class="mobile-runner-labels">
+              <span
+                v-for="member in group.runners"
+                :key="`${member.userId}-mobile-name`"
+                class="fw-black mobile-runner-label"
+                :style="{ backgroundColor: getRunnerTone(member.amount) }"
+              >
+                {{ member.profileImg }}
+              </span>
+            </div>
+
+            <div class="cluster-chip-row desktop-only">
               <span
                 v-for="member in group.runners"
                 :key="`${member.userId}-chip`"
@@ -87,7 +106,7 @@
               </span>
             </div>
 
-            <div class="cluster-stack">
+            <div class="cluster-stack desktop-only">
               <div
                 v-for="(member, idx) in group.runners.slice(0, 3)"
                 :key="`${member.userId}-bubble`"
@@ -103,7 +122,7 @@
               </div>
             </div>
 
-            <div class="cluster-names">
+            <div class="cluster-names desktop-only">
               <span
                 v-for="member in group.runners"
                 :key="`${member.userId}-name`"
@@ -126,8 +145,8 @@
       </div>
 
       <div class="scale-row">
-        <span class="fw-bold text-black-2">{{ toWon(groupStore.displayMin) }}</span>
-        <span class="fw-bold text-black-2">{{ toWon(groupStore.displayMax) }}</span>
+        <span class="fw-bold text-black-2 scale-min">{{ toWon(groupStore.displayMin) }}</span>
+        <span class="fw-bold text-black-2 scale-max">{{ toWon(groupStore.displayMax) }}</span>
       </div>
 
       <div class="legend bg-yellow-2">
@@ -364,7 +383,7 @@ const groupedRunners = computed(() => {
 .lane-wrap {
   position: relative;
   padding-top: 32px;
-  padding-bottom: 34px;
+  padding-bottom: 58px;
 }
 
 .lane {
@@ -419,6 +438,22 @@ const groupedRunners = computed(() => {
   gap: 4px;
 }
 
+.mobile-runner-labels {
+  display: none;
+}
+
+.mobile-runner-label {
+  font-size: 24px;
+  line-height: 1;
+  white-space: nowrap;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .lane-limit {
   position: absolute;
   top: 4px;
@@ -446,7 +481,7 @@ const groupedRunners = computed(() => {
 
 .limit-pill {
   position: absolute;
-  bottom: -34px;
+  bottom: 6px;
   transform: translateX(-50%);
   background-color: var(--red-1);
   color: var(--black-4);
@@ -574,6 +609,29 @@ const groupedRunners = computed(() => {
   font-size: 12px;
 }
 
+.scale-min,
+.scale-max {
+  position: relative;
+}
+
+.scale-min::before,
+.scale-max::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 8px);
+  width: 0;
+  height: 56px;
+  border-left: 2px dashed rgba(84, 91, 104, 0.35);
+}
+
+.scale-min::before {
+  left: 8px;
+}
+
+.scale-max::before {
+  right: 8px;
+}
+
 .legend {
   border-radius: 20px;
   height: 62px;
@@ -618,10 +676,43 @@ const groupedRunners = computed(() => {
 }
 
 @media (max-width: 768px) {
+  .lane-wrap {
+    padding-top: 20px;
+    padding-bottom: 64px;
+  }
+
+  .runner {
+    width: min(100%, 240px);
+    top: 43px;
+    transform: translate(-50%, -50%);
+  }
+
+  .desktop-only {
+    display: none !important;
+  }
+
+  .mobile-runner-labels {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 6px 16px;
+    max-width: 240px;
+  }
+
+  .legend {
+    display: none;
+  }
+
   .legend {
     align-items: flex-start;
     flex-direction: row;
     gap: 6px;
+  }
+
+  .scale-min::before,
+  .scale-max::before {
+    height: 56px;
   }
 }
 </style>

--- a/src/components/group/RankingBoard.vue
+++ b/src/components/group/RankingBoard.vue
@@ -158,7 +158,7 @@ const toWon = (value) => `${value.toLocaleString('ko-KR')} 원`
   }
 
   .amount {
-    font-size: 29px;
+    font-size: 22px;
   }
 }
 
@@ -176,7 +176,7 @@ const toWon = (value) => `${value.toLocaleString('ko-KR')} 원`
   }
 
   .amount {
-    font-size: 22px;
+    font-size: 18px;
   }
 }
 </style>


### PR DESCRIPTION
## 📄 PR 요약
> Group 화면의 모바일 반응형 UI를 개선했습니다.  
> RaceTrack에서 모바일 환경에 맞는 러너 표시 방식을 추가하고, GroupManager / RankingBoard의 레이아웃과 버튼 크기, 폰트 크기를 조정해 작은 화면에서도 정보가 겹치지 않도록 수정했습니다.

## ✍🏻 PR 상세
1. GroupManager 모바일 레이아웃을 개선했습니다.
   - 버튼 영역의 `margin-top`을 `auto`로 변경해 카드 하단에 자연스럽게 배치되도록 수정했습니다.
   - 버튼 최소 너비를 지정해 생성/참여 버튼 크기가 일정하게 보이도록 조정했습니다.
   - 모바일 해상도에서 팝업, 오버레이, 카드, 입력창, 라벨의 크기와 간격을 재조정했습니다.
   - 720px 이하, 420px 이하 구간별 반응형 스타일을 추가했습니다.

2. RaceTrack 모바일 전용 러너 표시 방식을 추가했습니다.
   - 기존에는 프로필 이미지, 금액, 이름, 상태 아이콘이 모두 노출되어 모바일에서 겹침이 발생했습니다.
   - 모바일에서는 `mobile-runner-label`을 사용해 프로필 이모지만 간단하게 표시하도록 변경했습니다.
   - 데스크탑 전용 요소에는 `desktop-only` 클래스를 추가해 모바일에서 숨기도록 처리했습니다.
     - 금액 칩
     - 프로필 이미지
     - 이름
     - 상태 아이콘
     - 클러스터 스택 및 이름 목록

3. RaceTrack의 모바일 레이아웃을 재조정했습니다.
   - 러너 위치 및 높이를 조정해 모바일에서 트랙과 겹치지 않도록 수정했습니다.
   - `lane-wrap` 하단 여백을 늘려 LIMIT 라벨과 스케일이 잘리지 않도록 개선했습니다.
   - LIMIT pill 위치를 상향 조정해 모바일에서도 한도 표시가 보이도록 수정했습니다.

4. 최소/최대 금액 스케일 표시를 개선했습니다.
   - `scale-min`, `scale-max` 클래스를 추가했습니다.
   - 최소/최대 금액 위에 점선 가이드를 표시해 어느 위치를 의미하는지 더 직관적으로 확인할 수 있도록 수정했습니다.

5. 모바일에서는 범례를 숨기도록 변경했습니다.
   - 작은 화면에서 공간을 많이 차지하던 legend 영역을 제거해 RaceTrack 정보가 더 잘 보이도록 했습니다.

6. RankingBoard 모바일 폰트 크기를 조정했습니다.
   - 모바일 환경에서 금액이 줄바꿈되거나 카드가 깨지지 않도록 `amount` 폰트 크기를 축소했습니다.

## 👀 참고사항
- RaceTrack 모바일 UI는 기존 데스크탑 UI를 단순 축소하지 않고, 모바일 전용 표시 방식으로 분기했습니다.
- 768px 이하에서는 `desktop-only` 요소가 숨겨지고, `mobile-runner-labels`만 노출됩니다.
- 720px / 420px 구간별로 팝업과 카드 레이아웃이 달라지므로 실제 모바일 화면 확인이 필요합니다.

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #90 