### PR TITLE
feat: 거래내역 수정 폼 날짜·타입 변경 기능 추가 및 메모 표시 개선  

### DIFF
--- a/src/components/calendar/TransactionList.vue
+++ b/src/components/calendar/TransactionList.vue
@@ -38,7 +38,7 @@
             />
           </div>
           <div class="tx-info">
-            <span class="tx-memo fw-semibold text-black-1">{{ tx.memo ?? '-' }}</span>
+            <span class="tx-memo fw-semibold text-black-1">{{ tx.memo || getCategoryInfo(tx.categoryId).name }}</span>
             <span class="tx-date fw-regular text-black-2">{{ formatDate(tx.date) }}</span>
           </div>
           <span
@@ -58,9 +58,28 @@
 
         <div v-if="editingId === tx.id" class="edit-form">
           <div class="edit-row">
+            <label class="edit-label fw-medium text-black-2">날짜</label>
+            <input v-model="editForm.date" type="date" class="edit-input fw-regular" />
+          </div>
+          <div class="edit-row">
+            <label class="edit-label fw-medium text-black-2">타입</label>
+            <div class="edit-type-toggle">
+              <button
+                class="type-btn fw-medium"
+                :class="editForm.type === 'income' ? 'type-active-income' : 'type-inactive'"
+                @click.stop="handleEditTypeChange('income')"
+              >수입</button>
+              <button
+                class="type-btn fw-medium"
+                :class="editForm.type === 'expense' ? 'type-active-expense' : 'type-inactive'"
+                @click.stop="handleEditTypeChange('expense')"
+              >지출</button>
+            </div>
+          </div>
+          <div class="edit-row">
             <label class="edit-label fw-medium text-black-2">카테고리</label>
             <select v-model="editForm.categoryId" class="edit-select fw-regular">
-              <option v-for="cat in filteredCategories(tx.type)" :key="cat.id" :value="cat.id">
+              <option v-for="cat in filteredCategories(editForm.type)" :key="cat.id" :value="cat.id">
                 {{ cat.name }}
               </option>
             </select>
@@ -107,7 +126,7 @@ const userStore = useUserStore()
 
 const selectedId = ref(null)
 const editingId = ref(null)
-const editForm = ref({ memo: '', amount: 0, categoryId: '' })
+const editForm = ref({ date: '', type: 'expense', memo: '', amount: 0, categoryId: '' })
 
 onMounted(async () => {
   const now = dayjs()
@@ -141,7 +160,18 @@ function toggleSelected(id) {
 
 function startEdit(tx) {
   editingId.value = tx.id
-  editForm.value = { memo: tx.memo ?? '', amount: tx.amount, categoryId: tx.categoryId }
+  editForm.value = {
+    date: tx.date,
+    type: tx.type,
+    memo: tx.memo ?? '',
+    amount: tx.amount,
+    categoryId: tx.categoryId,
+  }
+}
+
+function handleEditTypeChange(newType) {
+  editForm.value.type = newType
+  editForm.value.categoryId = newType === 'income' ? 'c1' : 'c3'
 }
 
 function cancelEdit() {
@@ -150,6 +180,8 @@ function cancelEdit() {
 
 async function submitEdit(id) {
   await transactionStore.updateTransaction(id, {
+    date: editForm.value.date,
+    type: editForm.value.type,
     memo: editForm.value.memo,
     amount: editForm.value.amount,
     categoryId: editForm.value.categoryId,
@@ -374,6 +406,36 @@ function formatAmount(type, amount) {
   display: flex;
   gap: 8px;
   margin-top: 4px;
+}
+
+.edit-type-toggle {
+  display: flex;
+  flex: 1;
+  gap: 6px;
+}
+
+.type-btn {
+  flex: 1;
+  padding: 8px 0;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.type-active-income {
+  background-color: var(--green-2);
+  color: #1a7a6e;
+}
+
+.type-active-expense {
+  background-color: var(--red-2);
+  color: var(--red-1);
+}
+
+.type-inactive {
+  background-color: var(--black-3);
+  color: var(--black-2);
 }
 
 /* 모바일 반응형 */


### PR DESCRIPTION
 ## 📄 PR 요약                                                                                                                                                                                                           
  > 거래내역 수정 폼에 날짜·타입 변경 기능을 추가하고, 메모가 없는 항목의 표시 방식을 개선합니다.                                                                                                                         
                                                                                                                                                                                                                          
  ## ✍🏻 PR 상세                                                                                                                                                                                                          
  1. 수정 폼에 날짜(date) 입력 필드 추가                                                                                                                                                                                  
  2. 수정 폼에 수입/지출 타입 토글 버튼 추가                
  3. 타입 변경 시 카테고리 자동 초기화 (수입 → c1, 지출 → c3)
  4. updateTransaction payload에 date, type 필드 포함
  5. 메모가 없는 거래 항목에 카테고리명을 대신 표시 (`??` → `||`)

  ## 👀 참고사항
  - 타입 변경 시 카테고리는 각 타입의 첫 번째 기본값으로 초기화됩니다.
  - 메모 빈 문자열("")도 없는 것으로 간주해 카테고리명으로 대체됩니다.

  ## ✅ 체크리스트
  - [x] 수정 폼에 날짜·타입 필드가 정상 렌더링됨                                                                                                                                                                          
  - [x] 타입 변경 시 카테고리 목록이 해당 타입으로 전환됨                                                                                                                                                                 
  - [x] 저장 시 날짜·타입·카테고리·메모·금액 모두 payload에 포함됨                                                                                                                                                        
  - [x] 메모 없는 항목에 카테고리명이 대신 표시됨                                                                                                                                                                         
  - [x] dev 서버에서 수정 저장 후 캘린더·뱃지에 즉시 반영 확인                                                                                                                                                            
  - [x] 취소 버튼 클릭 시 폼이 정상적으로 닫힘 확인                                                                                                                                                                       
  - [x] 불필요한 코드 없음   

  ## 🚪 연관된 이슈 번호
  Closes #92 