### PR TITLE
bugfix : groupManager 그룹 탈퇴 관련 버그 해결

### DIFF
--- a/src/components/group/GroupManager.vue
+++ b/src/components/group/GroupManager.vue
@@ -140,8 +140,8 @@ const onClickCreate = async () => {
   height: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
-  padding: 0 24px;
+  align-items: flex-start;
+  padding: 120px 24px 0;
   box-sizing: border-box;
 }
 

--- a/src/components/group/GroupManager.vue
+++ b/src/components/group/GroupManager.vue
@@ -113,7 +113,11 @@ const closePanel = () => {
 
 const onClickJoin = async () => {
   if (!joinCode.value || typeof groupStore.joinGroup !== 'function') return
-  await groupStore.joinGroup(userId, joinCode.value)
+  const result = await groupStore.joinGroup(userId, joinCode.value)
+  if (result == null) {
+    return
+  }
+
   const groupId = groupStore.currentGroup.id
   await userStore.updateGroupId(userId, groupId)
   await groupStore.loadGroup(groupId)

--- a/src/stores/useGroupStore.js
+++ b/src/stores/useGroupStore.js
@@ -84,21 +84,22 @@ export const useGroupStore = defineStore('group', {
       try {
         const response = await axios.get(`${BASE_URL}/${groupId}`)
         const groupData = response.data
-        if (!groupData) {
-          alert('존재하지 않는 레이스입니다. 레이스 코드를 확인해주세요.')
-          return
-        }
+        console.log('그룹 데이터:', groupData)
+
         if (groupData.memberIds.length >= 5) {
           alert('레이스 인원이 꽉 찼습니다.')
-          return
+          return null
         }
+
         const result = await axios.patch(`${BASE_URL}/${groupId}`, {
           memberIds: [...groupData.memberIds, userId],
         })
         this.currentGroup = result.data
+
+        return true
       } catch (e) {
-        console.error(e)
-        return
+        alert('존재하지 않는 레이스입니다. 레이스 코드를 확인해주세요.')
+        return null
       }
     }, //joinGroup
 
@@ -108,6 +109,8 @@ export const useGroupStore = defineStore('group', {
         const response = await axios.get(`${BASE_URL}/${groupId}`)
         const groupData = response.data
         const updatedMemberIds = groupData.memberIds.filter((id) => id !== userId)
+
+        this.resetRunners()
 
         if (updatedMemberIds.length === 0) {
           await axios.delete(`${BASE_URL}/${groupId}`)
@@ -233,6 +236,16 @@ export const useGroupStore = defineStore('group', {
         }
       })
     }, //setRunners
+
+    // runners 배열 초기화 하는 method
+    resetRunners() {
+      this.runners = []
+      this.maxRunner = { name: '', amount: 0 }
+      this.minRunner = { name: '', amount: 0 }
+      this.displayMax = 0
+      this.displayMin = 0
+      this.limitPosition = 0
+    }, //resetRunners
 
     // runners의 모든 필드를 업데이트 하는 method
     getRunnersDetails(runnersExpenses, runnersInfo) {


### PR DESCRIPTION
## 📄 PR 요약
> 그룹 가입 실패 시 이후 로직이 실행되지 않도록 수정하고, 그룹 탈퇴 시 RaceTrack 상태를 초기화하도록 변경했습니다.  
> 또한 GroupManager가 화면 중앙에 더 자연스럽게 위치하도록 레이아웃을 조정했습니다.

## ✍🏻 PR 상세
1. 그룹 가입 실패 시 이후 동작이 실행되지 않도록 수정했습니다.
   - `groupStore.joinGroup()`의 반환값을 받아 검증하도록 변경했습니다.
   - 그룹이 존재하지 않거나, 인원이 가득 찬 경우 `null`을 반환하도록 수정했습니다.
   - 가입 실패 시 `userStore.updateGroupId`, `loadGroup` 등 이후 로직이 실행되지 않도록 early return 처리했습니다.

2. `joinGroup` 예외 처리 방식을 정리했습니다.
   - 기존에는 실패 시 단순 `return`만 수행해 호출부에서 성공 여부를 구분하기 어려웠습니다.
   - 이제 실패 시 `null`, 성공 시 `true`를 반환하도록 통일했습니다.
   - 존재하지 않는 그룹 코드, 최대 인원 초과 상황 모두 동일한 방식으로 처리하도록 수정했습니다.

3. 그룹 탈퇴 시 RaceTrack 관련 상태를 초기화하도록 수정했습니다.
   - `leaveGroup` 실행 시 `resetRunners()`를 호출하도록 추가했습니다.
   - 이전 그룹의 러너, 최대/최소 금액, limit 위치 등의 값이 남아 다음 그룹 화면에 보이던 문제를 방지했습니다.

4. `resetRunners` 메서드를 추가했습니다.
   - 초기화 대상:
     - `runners`
     - `maxRunner`
     - `minRunner`
     - `displayMax`
     - `displayMin`
     - `limitPosition`
   - 그룹을 나가거나 새로운 그룹으로 이동할 때 RaceTrack 상태를 안전하게 초기화할 수 있도록 분리했습니다.

5. GroupManager 레이아웃을 조정했습니다.
   - 기존에는 세로 중앙 정렬(`align-items: center`)로 인해 화면이 작은 경우 카드가 위아래로 잘리는 문제가 있었습니다.
   - `align-items: flex-start`와 상단 패딩(`padding: 120px 24px 0`)을 적용해 카드가 화면 중앙보다 약간 위에 위치하도록 수정했습니다.
   - 결과적으로 모바일/작은 화면에서도 GroupManager가 더 안정적으로 보이도록 개선했습니다.

## 👀 참고사항
- `joinGroup()`은 이제 성공 여부를 반환하므로, 이후 다른 화면이나 기능에서도 동일하게 사용할 수 있습니다.
- 그룹 탈퇴 후 곧바로 다른 그룹에 가입하거나 새 그룹을 생성하는 시나리오를 실제로 확인할 필요가 있습니다.
- RaceTrack 관련 상태는 `resetRunners()`로만 초기화되므로, 그룹 이동 로직에서도 재사용 가능합니다.

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #94 